### PR TITLE
Rebuild dashboard layout for main and bulk views

### DIFF
--- a/Sidebar.html
+++ b/Sidebar.html
@@ -5,6 +5,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>أداة البحث</title>
+  
   <style>
     :root{
       color-scheme:dark;
@@ -23,7 +24,7 @@
       --border:rgba(255,255,255,0.07);
     }
     *{box-sizing:border-box;font-family:'Tajawal','Cairo','Segoe UI',sans-serif;}
-    body{margin:0;background:radial-gradient(circle at top left,#0c1424 0%,#05080f 55%,#020307 100%);color:var(--text);min-height:100vh;display:flex;justify-content:center;position:relative;}
+    body{margin:0;background:radial-gradient(circle at top left,#0c1424 0%,#05080f 55%,#020307 100%);color:var(--text);min-height:100vh;display:flex;justify-content:center;}
     body::before{content:"";position:fixed;inset:0;background:radial-gradient(circle at 20% 20%,rgba(45,212,255,.18),transparent 55%),radial-gradient(circle at 80% 10%,rgba(150,41,255,.18),transparent 60%);opacity:.75;pointer-events:none;z-index:-1;}
     body.drawer-open{overflow:hidden;}
     body,button,input,select,textarea{font-size:15px;}
@@ -41,11 +42,14 @@
     input:focus,select:focus,textarea:focus{border-color:var(--accent);box-shadow:0 0 0 3px var(--accent-dim);}
     textarea{min-height:130px;resize:vertical;line-height:1.6;}
     label.small{font-size:12px;color:var(--muted);display:block;margin-bottom:6px;}
-    .app-shell{width:100%;max-width:460px;padding:26px 18px 36px;display:flex;flex-direction:column;gap:18px;position:relative;}
-    @media(min-width:520px){.app-shell{max-width:520px;}}
-    .app-header{display:flex;align-items:center;gap:14px;}
+    .dashboard-shell{width:100%;max-width:520px;padding:24px 16px 56px;display:flex;flex-direction:column;gap:24px;position:relative;}
+    @media(min-width:720px){.dashboard-shell{max-width:840px;padding:32px 24px 72px;gap:28px;}}
+    @media(min-width:1024px){body{display:block;} .dashboard-shell{max-width:none;width:100%;padding:48px clamp(32px,4vw,96px);display:grid;grid-template-columns:300px minmax(0,1fr);gap:32px;align-items:start;}}
+    .dashboard-main{display:flex;flex-direction:column;gap:24px;}
+    @media(min-width:1024px){.dashboard-main{gap:32px;}}
+    .dashboard-header{display:flex;align-items:center;gap:16px;flex-wrap:wrap;}
     .hamburger{width:46px;height:46px;display:inline-flex;align-items:center;justify-content:center;border-radius:16px;background:var(--surface-strong);border:1px solid var(--border);color:var(--accent);box-shadow:0 10px 26px rgba(18,233,153,.18);}
-    .header-meta{margin-inline-start:auto;display:flex;flex-wrap:wrap;align-items:stretch;justify-content:flex-end;gap:14px;flex:1 1 auto;}
+    .header-meta{margin-inline-start:auto;display:flex;flex-wrap:wrap;align-items:stretch;gap:14px;}
     .counter-cluster{display:flex;align-items:center;justify-content:center;gap:12px;background:var(--surface-strong);padding:10px 14px;border-radius:18px;border:1px solid var(--border);box-shadow:0 12px 30px rgba(16,26,44,.36);flex-wrap:wrap;}
     .counter-mini{display:flex;flex-direction:column;align-items:center;justify-content:center;min-width:86px;padding:4px 0;flex:1 1 80px;}
     .counter-mini .label{font-size:11px;color:var(--muted);letter-spacing:.4px;}
@@ -55,62 +59,45 @@
     .section-chip .chip-value{color:var(--text-strong);font-size:13px;}
     .section-chip.is-empty{background:rgba(255,255,255,.04);border-color:rgba(255,255,255,.08);color:var(--muted);}
     .section-chip.is-empty .chip-value{color:var(--muted);}
-    .view-switch{display:flex;gap:10px;}
-    .view-tab{flex:1;background:var(--surface);border:1px solid transparent;border-radius:16px;padding:12px 14px;color:var(--muted);font-weight:700;}
+    .view-switch{display:flex;gap:10px;background:rgba(255,255,255,.04);padding:6px;border-radius:18px;backdrop-filter:blur(12px);}
+    .view-tab{flex:1;background:transparent;border:1px solid transparent;border-radius:16px;padding:12px 14px;color:var(--muted);font-weight:700;transition:background .18s ease,color .18s ease,border .18s ease,box-shadow .18s ease;}
     .view-tab.active{background:linear-gradient(135deg,var(--surface-strong),#1c2537);color:var(--accent);border-color:rgba(43,255,168,.22);box-shadow:0 12px 32px rgba(26,214,145,.22);}
-    .view-panel{display:none;flex-direction:column;gap:16px;}
-    .view-panel.active{display:flex;}
-    .stack-group{background:linear-gradient(150deg,rgba(18,26,38,.96),rgba(8,12,22,.9));border-radius:30px;border:1px solid rgba(255,255,255,.05);box-shadow:0 28px 72px rgba(5,12,22,.55);display:flex;flex-direction:column;overflow:hidden;}
-    .stack-row{padding:24px 26px;border-bottom:1px solid rgba(255,255,255,.04);display:flex;flex-direction:column;gap:18px;}
-    .stack-row:last-child{border-bottom:none;}
-    .stack-row--title{padding:30px 28px 18px;gap:10px;}
-    .stack-row--primary{padding:0;border-bottom:none;}
-    .primary-blocks{display:flex;flex-direction:column;gap:0;}
-    .primary-block{display:flex;flex-direction:column;gap:16px;padding:24px 28px;}
-    .primary-block + .primary-block{padding-top:0;}
-    .primary-block:not(:last-child){padding-bottom:0;}
-    .stack-title{margin:0;font-size:24px;font-weight:800;color:var(--accent);letter-spacing:.6px;}
-    .stack-subtitle{margin:0;font-size:13px;color:var(--muted);letter-spacing:.4px;}
-    .stack-box{display:flex;flex-direction:column;gap:18px;}
-    .log-slot{display:flex;flex-direction:column;gap:12px;}
-    .mobile-load-spot{display:none;}
-    .mobile-load-spot.show{display:block;}
-    .mobile-load-spot #loadCard{margin-top:18px;}
-    #logSlot > *{width:100%;}
-    .card{background:linear-gradient(145deg,var(--surface-strong),rgba(10,18,32,.96));border-radius:26px;padding:20px;border:1px solid rgba(255,255,255,.06);box-shadow:0 22px 50px rgba(5,12,22,.58);backdrop-filter:blur(6px);}
-    .card.flat{background:linear-gradient(150deg,rgba(18,26,38,.96),rgba(8,12,22,.92));border-color:rgba(255,255,255,.04);box-shadow:0 18px 42px rgba(6,10,20,.45);}
-    #loadCard{display:flex;flex-direction:column;gap:12px;background:var(--surface-strong);border-radius:22px;padding:18px;border:1px solid rgba(255,255,255,0.08);box-shadow:0 18px 42px rgba(6,10,20,.45);width:100%;max-width:none;}
-    #loadCard button{width:100%;font-size:15px;}
-    #loadCard .muted{font-size:12px;}
+    .view-panel{display:none;}
+    .view-panel.active{display:flex;flex-direction:column;gap:24px;}
+    .dashboard-card{background:linear-gradient(150deg,rgba(18,26,38,.96),rgba(8,12,22,.9));border-radius:28px;border:1px solid rgba(255,255,255,.05);box-shadow:0 28px 72px rgba(5,12,22,.55);display:flex;flex-direction:column;overflow:hidden;}
+    .card-section{padding:24px 26px;display:flex;flex-direction:column;gap:18px;border-bottom:1px solid rgba(255,255,255,.05);}
+    .card-section:last-child{border-bottom:none;}
+    .card-section h3{margin:0;font-size:16px;font-weight:800;color:var(--accent);letter-spacing:.4px;}
+    .surface-card{background:linear-gradient(145deg,var(--surface-strong),rgba(10,18,32,.94));border-radius:22px;padding:20px;border:1px solid rgba(255,255,255,.06);box-shadow:0 20px 48px rgba(6,10,20,.45);display:flex;flex-direction:column;gap:12px;}
+    .home-extras-grid{display:flex;flex-direction:column;gap:18px;}
+    @media(min-width:768px){.home-extras-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:18px;}}
+    #aiMountHere{display:flex;flex-direction:column;gap:16px;}
+    #resultsBox{padding:26px 22px;text-align:center;background:radial-gradient(circle at top,#1a2e2a 0%,#0b1118 55%,#090d13 100%);border:1px solid rgba(43,255,168,.22);box-shadow:0 28px 70px rgba(30,255,168,.18);display:flex;flex-direction:column;gap:12px;justify-content:center;border-radius:26px;}
+    #resultsBox .badges{display:flex;justify-content:center;gap:8px;flex-wrap:wrap;margin-bottom:0;}
     .badge{display:inline-flex;align-items:center;justify-content:center;padding:6px 12px;border-radius:999px;font-size:12px;font-weight:700;letter-spacing:.4px;border:1px solid rgba(255,255,255,.08);background:rgba(255,255,255,.04);}
     .badge--withdraw{color:#4de4a1;border-color:rgba(77,228,161,.32);background:rgba(77,228,161,.09);}
     .badge--agent{color:#38bdf8;border-color:rgba(56,189,248,.28);background:rgba(56,189,248,.08);}
     .badge--admin{color:#facc15;border-color:rgba(250,204,21,.32);background:rgba(250,204,21,.08);}
     .badge--dup{color:#ff5d75;border-color:rgba(255,93,117,.34);background:rgba(255,93,117,.12);}
     .badge--loading{color:var(--muted);border-color:rgba(255,255,255,.08);}
+    #statusChipsRow{display:flex;flex-wrap:wrap;gap:6px;justify-content:center;}
+    #statusChipsRow .chip{padding:4px 10px;border-radius:999px;background:rgba(255,255,255,.05);font-size:11px;color:var(--muted);}
+    .hidden-tools{display:none;}
+    #loadNote{margin-top:8px;color:var(--muted);font-size:12px;}
+    #advNote{color:var(--muted);font-size:13px;}
+    #pasteHint{color:var(--muted);}
     #nameText{font-size:15px;color:var(--muted);margin-bottom:8px;}
     #amountText{font-size:64px;font-weight:900;color:var(--accent);text-shadow:0 0 24px rgba(43,255,168,.45);margin-bottom:8px;}
     #discountInfo{font-size:13px;color:var(--muted);margin-bottom:6px;min-height:18px;}
     #multiText{font-size:12px;color:var(--muted);letter-spacing:.4px;}
     #extraDupInfo{font-size:12px;color:var(--muted);margin-top:12px;}
-    .row{display:flex;align-items:center;gap:12px;flex-wrap:wrap;}
-    .primary-cluster{display:flex;flex-direction:column;gap:18px;width:100%;}
-    .column{display:flex;flex-direction:column;gap:12px;}
-    .column.stretch>*{width:100%;}
-    .row.stretch>*,.row.stretch>button{flex:1 1 auto;}
-    .pill-group{display:flex;gap:10px;flex-wrap:wrap;}
-    .pill{flex:1;min-width:120px;background:var(--surface);padding:12px 14px;border-radius:18px;border:1px solid rgba(255,255,255,.04);display:flex;flex-direction:column;gap:6px;}
-    .pill .title{font-size:12px;color:var(--muted);}
-    .pill .value{font-weight:700;font-size:15px;color:var(--text);}
-    #resultsBox{padding:26px 22px;text-align:center;background:radial-gradient(circle at top,#1a2e2a 0%,#0b1118 55%,#090d13 100%);border:1px solid rgba(43,255,168,.22);box-shadow:0 28px 70px rgba(30,255,168,.18);display:flex;flex-direction:column;gap:12px;justify-content:center;border-radius:26px;}
-    #resultsBox .badges{display:flex;justify-content:center;gap:8px;flex-wrap:wrap;margin-bottom:0;}
     #searchCard{background:linear-gradient(160deg,rgba(18,26,38,.94),rgba(7,12,22,.88));border-radius:22px;box-shadow:0 18px 42px rgba(6,10,20,.4);border:1px solid rgba(255,255,255,.05);display:flex;flex-direction:column;gap:16px;padding:22px 20px;}
     #searchCard button{min-width:160px;}
-    #searchCard .column button{width:100%;}
-    #searchCard .actions{display:flex;justify-content:space-between;gap:12px;align-items:center;margin-top:8px;}
+    #searchCard .column{display:flex;flex-direction:column;gap:12px;}
+    #searchCard .actions{display:flex;justify-content:space-between;gap:12px;align-items:center;margin-top:4px;}
     #searchCard .actions .muted{flex:1;}
-    #advCard{background:linear-gradient(160deg,rgba(18,26,38,.96),rgba(7,10,20,.9));border-radius:26px;border:1px solid rgba(255,255,255,.06);box-shadow:0 22px 50px rgba(5,12,22,.48);display:flex;flex-direction:column;gap:24px;padding:28px;}
-    #advCard .row{gap:10px;}
+    #advCard{background:linear-gradient(160deg,rgba(18,26,38,.96),rgba(7,10,20,.9));border-radius:26px;border:1px solid rgba(255,255,255,.06);box-shadow:0 22px 50px rgba(5,12,22,.48);display:flex;flex-direction:column;gap:24px;padding:24px;}
+    #advCard .row{display:flex;gap:10px;flex-wrap:wrap;}
     #advCard select{background:var(--surface-strong);}
     #advCard .btn-ghost{border-color:rgba(43,255,168,.26);color:var(--accent);min-width:110px;}
     #advCard .btn-green{padding:16px;font-size:18px;border-radius:20px;}
@@ -125,7 +112,21 @@
     #discountInput,#applyDiscountToMessage,#enableSalaryCorrection{display:none;}
     .adv-subcard{background:rgba(255,255,255,.02);border:1px solid rgba(255,255,255,.05);border-radius:20px;padding:18px;display:flex;flex-direction:column;gap:12px;}
     #personCard{display:none;}
-    #bulkCard{display:flex;flex-direction:column;gap:24px;background:rgba(255,255,255,.02);border:1px solid rgba(255,255,255,.05);border-radius:22px;padding:22px;}
+    .log-slot{display:flex;flex-direction:column;gap:12px;}
+    .muted{color:var(--muted);}
+    .lastid{display:inline-flex;align-items:center;gap:6px;padding:6px 10px;border-radius:999px;border:1px solid rgba(255,255,255,.08);color:var(--muted);cursor:pointer;background:var(--surface-strong);font-size:12px;}
+    #lastIdPill{margin-inline-start:auto;}
+    .home-extras-grid .surface-card h3{margin:0;font-size:15px;font-weight:800;color:var(--accent);}
+    #bulkView .dashboard-card{gap:0;}
+    .bulk-card .card-section{gap:20px;}
+    .bulk-note{color:var(--muted);font-size:13px;}
+    .bulk-config-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:14px;}
+    .bulk-config-block{background:rgba(255,255,255,.02);border:1px solid rgba(255,255,255,.05);border-radius:18px;padding:16px;display:flex;flex-direction:column;gap:10px;}
+    .bulk-inline{display:flex;gap:12px;flex-wrap:wrap;}
+    .bulk-inline input{min-width:200px;}
+    .bulk-external{display:flex;flex-direction:column;gap:10px;padding:18px;border-radius:18px;background:rgba(255,255,255,.02);border:1px solid rgba(255,255,255,.05);}
+    .bulk-discount-row{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px;padding:14px 16px;border-radius:18px;background:rgba(255,255,255,.02);border:1px solid rgba(255,255,255,.05);align-items:center;}
+    .bulk-discount-row .row{display:flex;align-items:center;gap:8px;}
     .bulk-actions-row{display:flex;flex-wrap:wrap;gap:12px;}
     .bulk-actions-row button{flex:1 1 160px;}
     .bulk-progress-wrap{display:flex;flex-direction:column;gap:12px;}
@@ -133,7 +134,7 @@
     .bulk-progress-bar{height:100%;width:0;background:linear-gradient(90deg,var(--accent),#38bdf8);transition:width .3s ease;}
     .bulk-progress-text{display:flex;justify-content:space-between;align-items:center;gap:12px;color:var(--muted);font-size:13px;}
     .bulk-progress-text span:first-child{color:var(--accent);font-weight:800;}
-    .bulk-counters{display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:12px;}
+    .bulk-counters{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:12px;}
     .bulk-counter{background:rgba(255,255,255,.02);border:1px solid rgba(255,255,255,.05);border-radius:16px;padding:12px 14px;font-size:12px;color:var(--muted);}
     .bulk-counter b{color:var(--text-strong);}
     #bulkIds{min-height:220px;background:var(--surface-strong);border-radius:20px;border:1px solid rgba(255,255,255,.08);padding:18px;color:var(--text);box-shadow:0 16px 38px rgba(6,10,20,.4);}
@@ -142,27 +143,29 @@
     .bulk-table thead{background:var(--surface-strong);}
     .bulk-table th,.bulk-table td{padding:10px;border-bottom:1px solid rgba(255,255,255,.05);text-align:right;}
     .bulk-table tbody tr:nth-child(even){background:rgba(255,255,255,.02);}
+    .bulk-pagination{display:flex;justify-content:space-between;align-items:center;gap:14px;flex-wrap:wrap;}
     .bulk-page-btn{background:var(--surface-strong);color:var(--text);border:1px solid rgba(255,255,255,.08);border-radius:14px;padding:10px 18px;}
-    .bulk-config{display:flex;flex-direction:column;gap:20px;background:rgba(255,255,255,.02);border:1px solid rgba(255,255,255,.05);border-radius:22px;padding:22px;}
-    .bulk-config-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:14px;}
-    .bulk-config-block{background:rgba(255,255,255,.02);border:1px solid rgba(255,255,255,.04);border-radius:18px;padding:16px;display:flex;flex-direction:column;gap:12px;}
-    .bulk-inline{display:flex;gap:12px;flex-wrap:wrap;}
-    .bulk-inline input{min-width:200px;}
-    .bulk-external{display:flex;flex-direction:column;gap:10px;padding:18px;border-radius:18px;background:rgba(255,255,255,.02);border:1px solid rgba(255,255,255,.05);}
-    .bulk-discount-row{display:flex;align-items:center;gap:14px;flex-wrap:wrap;padding:14px 16px;border-radius:18px;background:rgba(255,255,255,.02);border:1px solid rgba(255,255,255,.05);}
-    .drawer-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.55);opacity:0;pointer-events:none;transition:opacity .2s ease;z-index:8;}
-    .drawer-backdrop.show{opacity:1;pointer-events:auto;}
-    #quickTools.drawer{position:fixed;top:40px;left:50%;transform:translate(-50%,-20px) scale(.96);width:90%;max-width:360px;background:var(--surface-strong);border:1px solid rgba(255,255,255,.08);border-radius:24px;padding:20px 18px;box-shadow:0 30px 80px rgba(0,0,0,.55);opacity:0;pointer-events:none;transition:opacity .2s ease,transform .22s ease;z-index:9;}
+    .bulk-page-info{color:var(--muted);font-size:12px;}
+    .dashboard-menu{display:flex;flex-direction:column;gap:18px;}
+    #quickTools.drawer{position:fixed;top:40px;left:50%;transform:translate(-50%,-20px) scale(.96);width:92%;max-width:360px;background:var(--surface-strong);border:1px solid rgba(255,255,255,.08);border-radius:24px;padding:24px 20px;box-shadow:0 30px 80px rgba(0,0,0,.55);opacity:0;pointer-events:none;transition:opacity .2s ease,transform .22s ease;z-index:9;}
     #quickTools.drawer.open{opacity:1;pointer-events:auto;transform:translate(-50%,0) scale(1);}
-    .drawer-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:18px;}
+    .drawer-header{display:flex;align-items:center;justify-content:space-between;gap:12px;}
     .drawer-title{font-size:18px;font-weight:800;color:var(--text);}
     .drawer-close{background:transparent;border:1px solid rgba(255,255,255,.12);color:var(--muted);width:38px;height:38px;border-radius:14px;}
-    .drawer-items{display:flex;flex-direction:column;gap:12px;}
-    .drawer-item{background:var(--surface);border-radius:18px;padding:14px 16px;text-align:center;font-weight:700;letter-spacing:.4px;border:1px solid rgba(255,255,255,.04);color:var(--text);}
-    .drawer-item.primary{background:linear-gradient(135deg,var(--accent),var(--accent-strong));color:#04140d;box-shadow:0 14px 38px var(--accent-dim);}
-    .drawer-toggle{display:flex;align-items:center;justify-content:space-between;background:var(--surface);border-radius:18px;padding:12px 16px;border:1px solid rgba(255,255,255,.04);}
-    .drawer-section{margin-top:12px;padding:14px 16px;border-radius:18px;background:var(--surface);border:1px solid rgba(255,255,255,.04);display:flex;flex-direction:column;gap:10px;}
-    .drawer-section .small{margin:0;}
+    .menu-stats{display:flex;gap:12px;flex-wrap:wrap;}
+    .menu-counter{flex:1;min-width:120px;background:var(--surface);border-radius:18px;padding:12px 14px;border:1px solid rgba(255,255,255,.05);display:flex;flex-direction:column;gap:4px;}
+    .menu-counter .label{font-size:12px;color:var(--muted);}
+    .menu-counter .value{font-size:17px;font-weight:800;color:var(--accent);}
+    #sectionChip{display:flex;align-items:center;justify-content:space-between;background:rgba(255,255,255,.03);border-radius:18px;border:1px solid rgba(255,255,255,.06);padding:12px 16px;}
+    #sectionChip .chip-label{color:var(--muted);}
+    #sectionChip .chip-value{color:var(--text-strong);font-weight:800;}
+    #sectionChip.is-empty{opacity:.6;}
+    #loadCard{display:flex;flex-direction:column;gap:12px;background:var(--surface);border-radius:22px;padding:18px;border:1px solid rgba(255,255,255,0.08);box-shadow:0 18px 42px rgba(6,10,20,.45);}
+    #loadCard button{width:100%;}
+    .menu-actions{display:flex;flex-direction:column;gap:10px;}
+    .menu-btn{width:100%;background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.08);border-radius:16px;padding:12px 16px;font-weight:700;color:var(--text);}
+    .menu-section{display:flex;flex-direction:column;gap:10px;background:rgba(255,255,255,.02);border:1px solid rgba(255,255,255,.05);border-radius:18px;padding:16px;}
+    .menu-toggle{display:flex;align-items:center;justify-content:space-between;background:rgba(255,255,255,.02);border:1px solid rgba(255,255,255,.05);border-radius:18px;padding:14px 16px;}
     .drawer-discount-row{display:flex;align-items:center;gap:10px;}
     .drawer-discount-row input{flex:1;}
     .drawer-discount-value{min-width:90px;text-align:center;color:var(--muted);font-size:13px;font-weight:700;padding:10px 12px;border-radius:14px;background:var(--surface-strong);border:1px solid rgba(255,255,255,.06);}
@@ -171,276 +174,258 @@
     #qtMode::after{content:'';position:absolute;top:3px;right:3px;width:24px;height:24px;border-radius:50%;background:#fff;box-shadow:0 2px 10px rgba(0,0,0,.35);transition:transform .2s ease,background .2s ease;}
     body.dark #qtMode{background:var(--accent);border-color:rgba(43,255,168,.32);}
     body.dark #qtMode::after{transform:translateX(-26px);background:#052016;}
-    .hidden-tools{display:none;}
-    .muted{color:var(--muted);}
-    .lastid{display:inline-flex;align-items:center;gap:6px;padding:6px 10px;border-radius:999px;border:1px solid rgba(255,255,255,.08);color:var(--muted);cursor:pointer;background:var(--surface-strong);font-size:12px;}
-    #lastIdPill{margin-inline-start:auto;}
-    #bulkCard .bulk-chip{background:rgba(255,93,117,.16);color:#ff8da4;border-radius:999px;padding:2px 8px;font-size:11px;}
-    .bulk-pagination{display:flex;justify-content:space-between;align-items:center;gap:14px;margin-top:12px;flex-wrap:wrap;}
-    .bulk-page-info{color:var(--muted);font-size:12px;}
-    #bulkStatusText{font-size:13px;}
-    #pasteHint{color:var(--muted);}
-    #advNote{color:var(--muted);font-size:13px;}
-    #loadNote{margin-top:8px;color:var(--muted);font-size:12px;}
-    #statusChipsRow{display:flex;flex-wrap:wrap;gap:6px;justify-content:center;}
-    #statusChipsRow .chip{padding:4px 10px;border-radius:999px;background:rgba(255,255,255,.05);font-size:11px;color:var(--muted);}
-    .view-panel footer{margin-top:8px;font-size:12px;color:var(--muted);text-align:center;}
-
-    #advCard .adv-control .title{display:none;}
-    @media(max-width:768px){
-      #advCard .adv-control{gap:6px;padding:12px;}
-      #advCard .adv-control--color input[type="color"]{height:52px;}
-    }
-
+    .drawer-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.55);opacity:0;pointer-events:none;transition:opacity .2s ease;z-index:8;}
+    .drawer-backdrop.show{opacity:1;pointer-events:auto;}
     @media(min-width:1024px){
-      body{padding:0;align-items:stretch;}
-      .app-shell{max-width:none;width:100%;padding:46px clamp(32px,5vw,72px);gap:32px;min-height:100vh;}
-      .view-switch{max-width:960px;margin:0 auto;width:100%;}
-      .view-tab{max-width:240px;}
-      #mainView .stack-group,#bulkView .stack-group{max-width:960px;margin:0 auto;}
-      .stack-row{padding-inline:36px;}
-      .stack-row--title{padding-inline:40px;padding-top:36px;}
-      #advCard .adv-control-grid{grid-template-columns:repeat(2,minmax(0,1fr));gap:16px;}
-      .bulk-actions-row button{flex:1 1 180px;}
-      #bulkIds{min-height:260px;}
+      #quickTools.drawer{position:sticky;top:0;left:auto;transform:none;opacity:1;pointer-events:auto;width:auto;max-width:320px;background:linear-gradient(150deg,rgba(18,26,38,.96),rgba(8,12,22,.9));}
+      #quickTools .drawer-close{display:none;}
+      .drawer-backdrop{display:none!important;}
+      .dashboard-header{padding-inline:0;}
     }
   </style>
+
 </head>
+
 <body class="dark">
-  <div class="app-shell">
-    <header class="app-header">
-      <button id="menuToggle" class="hamburger" type="button" aria-label="فتح القائمة">
-        <svg width="22" height="18" viewBox="0 0 22 18" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-          <rect x="1" y="1" width="20" height="2.4" rx="1.2" fill="currentColor" />
-          <rect x="1" y="7.8" width="20" height="2.4" rx="1.2" fill="currentColor" />
-          <rect x="1" y="14.6" width="20" height="2.4" rx="1.2" fill="currentColor" />
-        </svg>
-      </button>
-      <div class="header-meta">
-        <div class="counter-cluster">
-          <div class="counter-mini">
-            <span class="label">ملوّن</span>
-            <span id="qtColored" class="value">—</span>
-          </div>
-          <div class="counter-mini">
-            <span class="label">غير ملوّن</span>
-            <span id="qtUncolored" class="value">—</span>
-          </div>
+  <div class="dashboard-shell">
+    <aside id="quickTools" class="drawer dashboard-menu" aria-hidden="true">
+      <div class="drawer-header">
+        <span class="drawer-title">القائمة</span>
+        <button id="drawerClose" class="drawer-close" type="button" aria-label="إغلاق">✕</button>
+      </div>
+      <div class="menu-stats">
+        <div class="menu-counter">
+          <span class="label">ملوّن</span>
+          <span id="menuQtColored" class="value">—</span>
         </div>
-        <div id="sectionChip" class="section-chip is-empty">
-          <span class="chip-label">القسم</span>
-          <span id="headerSectionLabel" class="chip-value">—</span>
+        <div class="menu-counter">
+          <span class="label">غير ملوّن</span>
+          <span id="menuQtUncolored" class="value">—</span>
         </div>
       </div>
-    </header>
-    <div class="view-switch">
-      <button class="view-tab active" type="button" data-view="main">الصفحة الرئيسية</button>
-      <button class="view-tab" type="button" data-view="bulk">أداة البحث الجماعي</button>
-    </div>
-
-    <div id="mobileLoadCardSpot" class="mobile-load-spot"></div>
-
-    <section id="mainView" class="view-panel active">
-      <div id="mainStack" class="stack-group">
-        <div class="stack-row stack-row--title">
-          <h2 class="stack-title">الصفحة الرئيسية</h2>
+      <div id="menuSectionChip" class="section-chip is-empty">
+        <span class="chip-label">القسم</span>
+        <span id="menuSectionLabel" class="chip-value">—</span>
+      </div>
+      <div id="loadCard">
+        <button id="reloadBtn" class="btn-red" type="button">تحميل البيانات</button>
+        <div id="loadNote" class="muted"></div>
+      </div>
+      <div class="menu-actions">
+        <button id="menuHome" class="menu-btn" type="button">الصفحة الرئيسية</button>
+        <button id="menuBulk" class="menu-btn" type="button">أداة البحث الجماعي</button>
+        <button id="refreshSheetsBtn" class="menu-btn" type="button">تحديث قائمة الأوراق</button>
+      </div>
+      <div class="menu-section">
+        <label class="small" for="menuSection">القسم الحالي</label>
+        <select id="menuSection"></select>
+        <div id="menuSectionStatus" class="drawer-note"></div>
+      </div>
+      <div class="menu-toggle">
+        <span>الوضع الداكن</span>
+        <button id="qtMode" type="button" aria-label="تبديل الوضع"></button>
+      </div>
+      <div class="menu-section">
+        <label class="small" for="menuDiscount">الخصم الفوري (%)</label>
+        <div class="drawer-discount-row">
+          <input id="menuDiscount" type="number" min="0" max="100" step="0.1" inputmode="decimal" placeholder="0">
+          <span id="menuDiscountValue" class="drawer-discount-value">بدون خصم</span>
         </div>
+        <div class="drawer-note">يُطبّق مباشرة على نتيجة البحث الفردي.</div>
+      </div>
+      <div class="hidden-tools">
+        <button id="qtHideLoad" type="button"></button>
+        <button id="qtHidePerson" type="button"></button>
+        <label><input id="qtDisablePerson" type="checkbox"></label>
+        <button id="qtRefreshCnt" type="button"></button>
+      </div>
+    </aside>
 
-        <div class="stack-row stack-row--primary">
-          <div class="primary-blocks">
-            <div class="primary-block primary-block--results">
-              <h3 class="stack-subtitle">خانة النتائج</h3>
-              <div id="resultsBox">
-                <div class="badges">
-                  <span id="statusBadge" class="badge badge--loading">—</span>
-                  <span id="dupBadge" class="badge badge--dup" style="display:none">مكرر</span>
-                  <span id="statusChipsRow"></span>
-                </div>
-                <div id="nameText" class="subline">—</div>
-                <div id="amountText" class="amountBig">—</div>
-                <div id="discountInfo" style="display:none"></div>
-                <div id="multiText" class="subline"></div>
-                <div id="extraDupInfo" class="muted" style="margin-top:12px"></div>
-              </div>
+    <div class="dashboard-main">
+      <header class="dashboard-header">
+        <button id="menuToggle" class="hamburger" type="button" aria-label="فتح القائمة">
+          <svg width="22" height="18" viewBox="0 0 22 18" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <rect x="1" y="1" width="20" height="2.4" rx="1.2" fill="currentColor" />
+            <rect x="1" y="7.8" width="20" height="2.4" rx="1.2" fill="currentColor" />
+            <rect x="1" y="14.6" width="20" height="2.4" rx="1.2" fill="currentColor" />
+          </svg>
+        </button>
+        <div class="header-meta">
+          <div class="counter-cluster">
+            <div class="counter-mini">
+              <span class="label">ملوّن</span>
+              <span id="qtColored" class="value">—</span>
             </div>
-
-            <div class="primary-block primary-block--search">
-              <h3 class="stack-subtitle">خانة البحث</h3>
-              <div id="searchCard">
-                <label class="small">ID للبحث</label>
-                <div class="column stretch">
-                  <input id="idInput" type="text" placeholder="أدخل ID هنا" autocomplete="off" inputmode="numeric">
-                  <button id="pasteSearchBtn" class="btn-blue" type="button">لصق ثم بحث</button>
-                </div>
-                <div class="actions">
-                  <div id="pasteHint" class="muted"></div>
-                  <div id="lastIdPill" class="lastid" style="display:none">آخر ID: <b id="lastIdText"></b></div>
-                </div>
-              </div>
-            </div>
-
-            <div class="primary-block primary-block--single">
-              <h3 class="stack-subtitle">قسم التنفيذ الفردي</h3>
-              <div id="advCard">
-                <div class="adv-top">
-                  <button id="advRunBtn" class="btn-green" type="button">تنفيذ (حسب النتيجة)</button>
-                  <div id="advNote" class="muted"></div>
-                </div>
-
-                <div class="adv-control-grid">
-                  <div class="pill adv-control">
-                    <span class="title">الهدف</span>
-                    <select id="sheetSelect" aria-label="الهدف"></select>
-                  </div>
-                  <div class="pill adv-control">
-                    <span class="title">التنفيذ</span>
-                    <select id="targetMode" aria-label="وضع التنفيذ">
-                      <option value="agent">الوكيل فقط</option>
-                      <option value="both" selected>الإدارة + الوكيل</option>
-                    </select>
-                  </div>
-                  <div class="pill adv-control adv-control--color">
-                    <span class="title">لون الإدارة</span>
-                    <input id="adminColor" type="color" value="#fde68a" aria-label="لون الإدارة">
-                  </div>
-                  <div class="pill adv-control adv-control--color">
-                    <span class="title">لون سحب وكالة</span>
-                    <input id="withdrawColor" type="color" value="#9629ff" aria-label="لون سحب وكالة">
-                  </div>
-                </div>
-
-                <div class="row stretch">
-                  <input id="newSheetName" type="text" placeholder="اسم ورقة جديدة (داخل الإدارة)">
-                  <button id="createSheetBtn" class="btn-ghost" type="button">إنشاء</button>
-                </div>
-
-                <div class="row toggles-row">
-                  <div class="row" style="gap:8px;align-items:center;">
-                    <label class="small" style="margin:0;">الخصم %</label>
-                    <input id="discountInput" type="number" min="0" max="100" value="0" step="1" style="width:110px">
-                  </div>
-                  <div class="toggle-chip">
-                    <span class="switch-label">الخصم لحظيًا</span>
-                    <label class="ios-toggle">
-                      <input id="applyDiscountToMessage" type="checkbox">
-                      <span class="slider"></span>
-                    </label>
-                  </div>
-                  <div class="toggle-chip">
-                    <span class="switch-label">تصحيح الراتب</span>
-                    <label class="ios-toggle">
-                      <input id="enableSalaryCorrection" type="checkbox">
-                      <span class="slider"></span>
-                    </label>
-                  </div>
-                </div>
-
-                <div class="adv-subcard" id="personCard">
-                  <div class="row" style="justify-content:space-between; align-items:center">
-                    <strong>بيانات صاحب الـID</strong>
-                    <div class="row" style="gap:6px; flex:0 0 auto">
-                      <button id="copyMsgBtn" class="btn-green" type="button">نسخ الرسالة</button>
-                      <button id="colorAllBtn" class="btn-ghost" type="button" title="تلوين كل الـIDs لهذا الشخص بسرعة">تلوين الكل</button>
-                    </div>
-                  </div>
-                  <div id="personNote" class="muted" style="margin-top:6px">—</div>
-                  <textarea id="personMsg" rows="8" style="margin-top:8px;" readonly></textarea>
-                </div>
-              </div>
+            <div class="counter-mini">
+              <span class="label">غير ملوّن</span>
+              <span id="qtUncolored" class="value">—</span>
             </div>
           </div>
-        </div>
-
-        <div class="stack-row stack-row--log">
-          <h3 class="stack-subtitle">زر السجل</h3>
-          <div class="stack-box">
-            <div id="logSlot" class="log-slot"></div>
+          <div id="sectionChip" class="section-chip is-empty">
+            <span class="chip-label">القسم</span>
+            <span id="headerSectionLabel" class="chip-value">—</span>
           </div>
         </div>
+      </header>
 
-        <div class="stack-row stack-row--load">
-          <h3 class="stack-subtitle">تحميل البيانات</h3>
-          <div class="stack-box">
-            <div class="load-card" id="loadCard">
-              <button id="reloadBtn" class="btn-red" type="button">تحميل البيانات</button>
-              <div id="loadNote" class="muted"></div>
-            </div>
-          </div>
-        </div>
+      <div class="view-switch">
+        <button class="view-tab active" type="button" data-view="main">الصفحة الرئيسية</button>
+        <button class="view-tab" type="button" data-view="bulk">أداة البحث الجماعي</button>
       </div>
 
-      <div id="bulkMobileMount" class="span2" style="display:none"></div>
-    </section>
+      <section id="mainView" class="view-panel active">
+        <div class="dashboard-card home-card">
+          <div class="card-section">
+            <h3>النتائج</h3>
+            <div id="resultsBox">
+              <div class="badges">
+                <span id="statusBadge" class="badge badge--loading">—</span>
+                <span id="dupBadge" class="badge badge--dup" style="display:none">مكرر</span>
+                <span id="statusChipsRow"></span>
+              </div>
+              <div id="nameText" class="subline">—</div>
+              <div id="amountText" class="amountBig">—</div>
+              <div id="discountInfo" style="display:none"></div>
+              <div id="multiText" class="subline"></div>
+              <div id="extraDupInfo" class="muted" style="margin-top:12px"></div>
+            </div>
+          </div>
 
-    <section id="bulkView" class="view-panel">
-      <div id="bulkStack" class="stack-group">
-        <div class="stack-row stack-row--title">
-          <h2 class="stack-title">أداة البحث الجماعي</h2>
-        </div>
+          <div class="card-section">
+            <h3>البحث</h3>
+            <div id="searchCard">
+              <label class="small">ID للبحث</label>
+              <div class="column">
+                <input id="idInput" type="text" placeholder="أدخل ID هنا" autocomplete="off" inputmode="numeric">
+                <button id="pasteSearchBtn" class="btn-blue" type="button">لصق ثم بحث</button>
+              </div>
+              <div class="actions">
+                <div id="pasteHint" class="muted"></div>
+                <div id="lastIdPill" class="lastid" style="display:none">آخر ID: <b id="lastIdText"></b></div>
+              </div>
+            </div>
+          </div>
 
-        <div class="stack-row stack-row--goal">
-          <h3 class="stack-subtitle">قسم الهدف و المنطق</h3>
-          <div class="stack-box">
-            <div class="bulk-note" id="bulkStatusText">ألصق IDs وسيتم التحليل تلقائيًا.</div>
-            <div id="bulkConfigCard" class="bulk-config">
-              <div class="bulk-config-grid">
-                <div class="bulk-config-block">
-                  <label class="small">النطاق</label>
-                  <select id="bulkScope">
+          <div class="card-section">
+            <h3>التنفيذ الفردي</h3>
+            <div id="advCard">
+              <div class="adv-top">
+                <button id="advRunBtn" class="btn-green" type="button">تنفيذ (حسب النتيجة)</button>
+                <div id="advNote" class="muted"></div>
+              </div>
+
+              <div class="adv-control-grid">
+                <div class="pill adv-control">
+                  <span class="title">الهدف</span>
+                  <select id="sheetSelect" aria-label="الهدف"></select>
+                </div>
+                <div class="pill adv-control">
+                  <span class="title">التنفيذ</span>
+                  <select id="targetMode" aria-label="وضع التنفيذ">
                     <option value="agent">الوكيل فقط</option>
                     <option value="both" selected>الإدارة + الوكيل</option>
-                    <option value="all">الكل (يشمل الخارجي)</option>
                   </select>
                 </div>
-                <div class="bulk-config-block">
-                  <label class="small">ورقة الهدف</label>
-                  <div class="row" style="gap:6px; align-items:center">
-                    <select id="bulkTargetSheet" style="flex:1"></select>
-                    <button id="bulkRefreshSheets" class="btn-ghost" title="تحديث قائمة الأوراق" style="flex:0 0 auto">↻</button>
+                <div class="pill adv-control adv-control--color">
+                  <span class="title">لون الإدارة</span>
+                  <input id="adminColor" type="color" value="#fde68a" aria-label="لون الإدارة">
+                </div>
+                <div class="pill adv-control adv-control--color">
+                  <span class="title">لون سحب وكالة</span>
+                  <input id="withdrawColor" type="color" value="#9629ff" aria-label="لون سحب وكالة">
+                </div>
+              </div>
+
+              <div class="row" style="gap:10px;">
+                <input id="newSheetName" type="text" placeholder="اسم ورقة جديدة (داخل الإدارة)">
+                <button id="createSheetBtn" class="btn-ghost" type="button">إنشاء</button>
+              </div>
+
+              <div class="adv-subcard" id="personCard">
+                <div class="row" style="justify-content:space-between; align-items:center">
+                  <strong>بيانات صاحب الـID</strong>
+                  <div class="row" style="gap:6px; flex:0 0 auto">
+                    <button id="copyMsgBtn" class="btn-green" type="button">نسخ الرسالة</button>
+                    <button id="colorAllBtn" class="btn-ghost" type="button" title="تلوين كل الـIDs لهذا الشخص بسرعة">تلوين الكل</button>
                   </div>
                 </div>
-              </div>
-
-              <div class="bulk-inline">
-                <input id="bulkNewSheet" type="text" placeholder="اسم ورقة جديدة (داخل الإدارة)">
-                <button id="bulkCreateSheet" class="btn-ghost">إنشاء ورقة</button>
-              </div>
-
-              <div id="bulkExternalWrap" class="bulk-external" style="display:none;">
-                <label class="small" style="display:block">ورقة الهدف (خارجي) <span id="bulkExternalFileLabel" class="muted"></span></label>
-                <div class="row" style="gap:6px; align-items:center">
-                  <select id="bulkExternalTargetSheet" style="flex:1"></select>
-                  <button id="bulkExternalRefreshSheets" class="btn-ghost" title="تحديث قائمة الأوراق الخارجية" style="flex:0 0 auto">↻</button>
-                </div>
-                <div class="row stretch" style="margin-top:8px">
-                  <input id="bulkExternalNewSheet" type="text" placeholder="اسم ورقة جديدة (خارجية)">
-                  <button id="bulkExternalCreateSheet" class="btn-ghost">إنشاء</button>
-                </div>
-                <div id="bulkExternalNote" class="muted" style="margin-top:6px"></div>
-              </div>
-
-              <div class="bulk-discount-row">
-                <div class="row" style="gap:8px;align-items:center;">
-                  <label class="small" style="margin:0;">لون الإدارة</label>
-                  <input id="bulkAdminColor" type="color" value="#fde68a" aria-label="لون الإدارة">
-                </div>
-                <div class="row" style="gap:8px;align-items:center;">
-                  <label class="small" style="margin:0;">لون السحب</label>
-                  <input id="bulkWithdrawColor" type="color" value="#9629ff" aria-label="لون سحب وكالة">
-                </div>
-                <div class="row" style="gap:8px;align-items:center;">
-                  <label class="small" style="margin:0;">الخصم %</label>
-                  <input id="bulkDiscount" type="number" min="0" max="100" value="0" step="1" style="width:110px">
-                </div>
-                <div class="muted" id="bulkDiscountNote">يُطبّق تلقائيًا على النتائج.</div>
+                <div id="personNote" class="muted" style="margin-top:6px">—</div>
+                <textarea id="personMsg" rows="8" style="margin-top:8px;" readonly></textarea>
               </div>
             </div>
           </div>
-        </div>
 
-        <div class="stack-row stack-row--execute">
-          <h3 class="stack-subtitle">قسم التنفيذ الجماعي</h3>
-          <div class="stack-box">
+          <div class="card-section">
+            <h3>السجل والمقترحات</h3>
+            <div class="home-extras-grid">
+              <div class="surface-card">
+                <h3>زر السجل</h3>
+                <div id="logSlot" class="log-slot"></div>
+              </div>
+              <div id="aiMountHere"></div>
+            </div>
+          </div>
+        </div>
+        <div id="bulkMobileMount" style="display:none"></div>
+      </section>
+
+      <section id="bulkView" class="view-panel">
+        <div class="dashboard-card bulk-card">
+          <div class="card-section">
+            <h3>النطاق و ورقة الهدف</h3>
+            <div id="bulkStatusText" class="bulk-note">ألصق IDs وسيتم التحليل تلقائيًا.</div>
+            <div class="bulk-config-grid">
+              <div class="bulk-config-block">
+                <label class="small">النطاق</label>
+                <select id="bulkScope">
+                  <option value="agent">الوكيل فقط</option>
+                  <option value="both" selected>الإدارة + الوكيل</option>
+                  <option value="all">الكل (يشمل الخارجي)</option>
+                </select>
+              </div>
+              <div class="bulk-config-block">
+                <label class="small">ورقة الهدف</label>
+                <div class="row" style="gap:6px; align-items:center">
+                  <select id="bulkTargetSheet" style="flex:1"></select>
+                  <button id="bulkRefreshSheets" class="btn-ghost" title="تحديث قائمة الأوراق" style="flex:0 0 auto">↻</button>
+                </div>
+              </div>
+            </div>
+            <div class="bulk-inline">
+              <input id="bulkNewSheet" type="text" placeholder="اسم ورقة جديدة (داخل الإدارة)">
+              <button id="bulkCreateSheet" class="btn-ghost">إنشاء ورقة</button>
+            </div>
+            <div id="bulkExternalWrap" class="bulk-external" style="display:none;">
+              <label class="small" style="display:block">ورقة الهدف (خارجي) <span id="bulkExternalFileLabel" class="muted"></span></label>
+              <div class="row" style="gap:6px; align-items:center">
+                <select id="bulkExternalTargetSheet" style="flex:1"></select>
+                <button id="bulkExternalRefreshSheets" class="btn-ghost" title="تحديث قائمة الأوراق الخارجية" style="flex:0 0 auto">↻</button>
+              </div>
+              <div class="row" style="gap:10px; margin-top:8px;">
+                <input id="bulkExternalNewSheet" type="text" placeholder="اسم ورقة جديدة (خارجية)">
+                <button id="bulkExternalCreateSheet" class="btn-ghost">إنشاء</button>
+              </div>
+              <div id="bulkExternalNote" class="muted" style="margin-top:6px"></div>
+            </div>
+            <div class="bulk-discount-row">
+              <div class="row" style="gap:8px;align-items:center;">
+                <label class="small" style="margin:0;">لون الإدارة</label>
+                <input id="bulkAdminColor" type="color" value="#fde68a" aria-label="لون الإدارة">
+              </div>
+              <div class="row" style="gap:8px;align-items:center;">
+                <label class="small" style="margin:0;">لون السحب</label>
+                <input id="bulkWithdrawColor" type="color" value="#9629ff" aria-label="لون سحب وكالة">
+              </div>
+              <div class="row" style="gap:8px;align-items:center;">
+                <label class="small" style="margin:0;">الخصم %</label>
+                <input id="bulkDiscount" type="number" min="0" max="100" value="0" step="1" style="width:110px">
+              </div>
+              <div class="muted" id="bulkDiscountNote">يُطبّق تلقائيًا على النتائج.</div>
+            </div>
+          </div>
+
+          <div class="card-section">
+            <h3>قسم التنفيذ الجماعي</h3>
             <div id="bulkCard" class="bulk-execute">
               <div class="bulk-actions-row">
                 <button id="bulkPasteBtn" class="btn-blue">لصق ثم بحث</button>
@@ -449,7 +434,6 @@
                 <button id="bulkCopyAllBtn" class="btn-ghost" disabled>نسخ الكل</button>
                 <button id="bulkCopySalaryBtn" class="btn-ghost" disabled>نسخ الراتب فقط</button>
               </div>
-
               <div class="bulk-progress-wrap">
                 <div class="bulk-progress">
                   <div id="bulkProgressBar" class="bulk-progress-bar"></div>
@@ -459,7 +443,6 @@
                   <span id="bulkSummaryText"></span>
                 </div>
               </div>
-
               <div class="bulk-counters">
                 <div class="bulk-counter">عدد الإدخالات: <b id="bulkCountTotal">0</b></div>
                 <div class="bulk-counter">ملوّن: <b id="bulkCountColored">0</b></div>
@@ -468,18 +451,14 @@
               </div>
             </div>
           </div>
-        </div>
 
-        <div class="stack-row stack-row--paste">
-          <h3 class="stack-subtitle">قسم خانة اللصق</h3>
-          <div class="stack-box">
+          <div class="card-section">
+            <h3>قسم خانة اللصق</h3>
             <textarea id="bulkIds" placeholder="ألصق عدة IDs (سطر لكل ID أو مفصولة بمسافات)"></textarea>
           </div>
-        </div>
 
-        <div class="stack-row stack-row--results">
-          <h3 class="stack-subtitle">قسم النتائج</h3>
-          <div class="stack-box">
+          <div class="card-section">
+            <h3>قسم النتائج</h3>
             <div class="bulk-table-wrap">
               <table class="bulk-table">
                 <thead>
@@ -502,47 +481,12 @@
             </div>
           </div>
         </div>
-      </div>
-
-    </section>
+      </section>
+    </div>
   </div>
 
   <div id="drawerBackdrop" class="drawer-backdrop"></div>
-  <aside id="quickTools" class="drawer" aria-hidden="true">
-    <div class="drawer-header">
-      <span class="drawer-title">القائمة</span>
-      <button id="drawerClose" class="drawer-close" type="button" aria-label="إغلاق">✕</button>
-    </div>
-    <div class="drawer-items">
-      <button id="menuReload" class="drawer-item primary" type="button">تحميل البيانات</button>
-      <button id="menuHome" class="drawer-item" type="button">الصفحة الرئيسية</button>
-      <button id="menuBulk" class="drawer-item" type="button">أداة البحث الجماعي</button>
-      <button id="refreshSheetsBtn" class="drawer-item" type="button">تحديث قائمة الأوراق</button>
-      <div class="drawer-section">
-        <label class="small" for="menuSection">القسم الحالي</label>
-        <select id="menuSection"></select>
-        <div id="menuSectionStatus" class="drawer-note"></div>
-      </div>
-      <div class="drawer-toggle">
-        <span>الوضع الداكن</span>
-        <button id="qtMode" type="button" aria-label="تبديل الوضع"></button>
-      </div>
-      <div class="drawer-section">
-        <label class="small" for="menuDiscount">الخصم الفوري (%)</label>
-        <div class="drawer-discount-row">
-          <input id="menuDiscount" type="number" min="0" max="100" step="0.1" inputmode="decimal" placeholder="0">
-          <span id="menuDiscountValue" class="drawer-discount-value">بدون خصم</span>
-        </div>
-        <div class="drawer-note">يُطبّق مباشرة على نتيجة البحث الفردي.</div>
-      </div>
-    </div>
-    <div class="hidden-tools">
-      <button id="qtHideLoad" type="button"></button>
-      <button id="qtHidePerson" type="button"></button>
-      <label><input id="qtDisablePerson" type="checkbox"></label>
-      <button id="qtRefreshCnt" type="button"></button>
-    </div>
-  </aside>
+
 
   <script>
     // عناصر عامة
@@ -586,6 +530,8 @@
     const pasteHint      = document.getElementById('pasteHint');
     const headerSectionLabelEl = document.getElementById('headerSectionLabel');
     const sectionChipEl        = document.getElementById('sectionChip');
+    const menuSectionChipEl   = document.getElementById('menuSectionChip');
+    const menuSectionLabelEl  = document.getElementById('menuSectionLabel');
 
     const resultsBox  = document.getElementById('resultsBox');
     const statusBadge = document.getElementById('statusBadge');
@@ -683,6 +629,8 @@
     // أدوات سريعة
     const qtColored = document.getElementById('qtColored');
     const qtUncolored = document.getElementById('qtUncolored');
+    const menuQtColored = document.getElementById('menuQtColored');
+    const menuQtUncolored = document.getElementById('menuQtUncolored');
     const qtMode = document.getElementById('qtMode');
     const qtHide = document.getElementById('qtHideLoad');
 
@@ -832,6 +780,13 @@
       if (sectionChipEl) {
         sectionChipEl.classList.toggle('is-empty', !safe);
         sectionChipEl.title = safe ? `القسم الحالي: ${safe}` : 'لم يتم اختيار قسم';
+      }
+      if (menuSectionLabelEl) {
+        menuSectionLabelEl.textContent = safe || '—';
+      }
+      if (menuSectionChipEl) {
+        menuSectionChipEl.classList.toggle('is-empty', !safe);
+        menuSectionChipEl.title = safe ? `القسم الحالي: ${safe}` : 'لم يتم اختيار قسم';
       }
       if (window.__aiClient && typeof window.__aiClient.setActiveSection === 'function') {
         window.__aiClient.setActiveSection(safe);
@@ -2046,14 +2001,22 @@
           if(!res || !res.ok){
             if (qtColored) qtColored.textContent = '—';
             if (qtUncolored) qtUncolored.textContent = '—';
+            if (menuQtColored) menuQtColored.textContent = '—';
+            if (menuQtUncolored) menuQtUncolored.textContent = '—';
             return;
           }
-          if (qtColored) qtColored.textContent   = fmtNum(res.coloredRows || 0);
-          if (qtUncolored) qtUncolored.textContent = fmtNum(res.uncoloredRows || 0);
+          const coloredVal = fmtNum(res.coloredRows || 0);
+          const uncoloredVal = fmtNum(res.uncoloredRows || 0);
+          if (qtColored) qtColored.textContent = coloredVal;
+          if (qtUncolored) qtUncolored.textContent = uncoloredVal;
+          if (menuQtColored) menuQtColored.textContent = coloredVal;
+          if (menuQtUncolored) menuQtUncolored.textContent = uncoloredVal;
         })
         .withFailureHandler(()=>{
           if (qtColored) qtColored.textContent = '—';
           if (qtUncolored) qtUncolored.textContent = '—';
+          if (menuQtColored) menuQtColored.textContent = '—';
+          if (menuQtUncolored) menuQtUncolored.textContent = '—';
         })
         .getLiveStatsForFooter(pct);
     }


### PR DESCRIPTION
## Summary
- redesign the shared styles to introduce a responsive dashboard shell, refreshed cards, and a persistent control sidebar
- rebuild the sidebar menu with counters, loading controls, section picker, dark mode toggle, and discount management inside a single panel
- consolidate the main and bulk views into unified dashboard cards while keeping the log and bulk tooling logic intact, including syncing section labels and counters across the UI

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e561bd19bc832484db9eba0fe0c146