### PR TITLE
Add menu toggle for person data and simplify bulk inputs

### DIFF
--- a/Sidebar.html
+++ b/Sidebar.html
@@ -5,545 +5,371 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>أداة البحث</title>
+  
   <style>
     :root{
       color-scheme:dark;
       --bg:#05080f;
-      --surface:#0f151f;
-      --surface-soft:#121b27;
-      --surface-strong:#182234;
+      --surface:#121b27;
+      --surface-soft:#0f151f;
       --accent:#2bffa8;
       --accent-strong:#1ddf8d;
-      --accent-dim:rgba(43,255,168,0.14);
       --muted:#7f8ba5;
       --text:#e8f7ff;
       --text-strong:#ffffff;
-      --danger:#ff5d75;
-      --warning:#ffd166;
-      --border:rgba(255,255,255,0.07);
     }
     *{box-sizing:border-box;font-family:'Tajawal','Cairo','Segoe UI',sans-serif;}
-    body{margin:0;background:radial-gradient(circle at top left,#0c1424 0%,#05080f 55%,#020307 100%);color:var(--text);min-height:100vh;display:flex;justify-content:center;position:relative;}
-    body::before{content:"";position:fixed;inset:0;background:radial-gradient(circle at 20% 20%,rgba(45,212,255,.18),transparent 55%),radial-gradient(circle at 80% 10%,rgba(150,41,255,.18),transparent 60%);opacity:.75;pointer-events:none;z-index:-1;}
+    body{margin:0;background:#05080f;color:var(--text);min-height:100vh;display:flex;justify-content:center;padding:24px 16px;}
+    body::before{content:"";position:fixed;inset:0;background:radial-gradient(circle at 20% 20%,rgba(45,212,255,.18),transparent 55%),radial-gradient(circle at 80% 10%,rgba(150,41,255,.18),transparent 60%);opacity:.6;pointer-events:none;z-index:-1;}
     body.drawer-open{overflow:hidden;}
     body,button,input,select,textarea{font-size:15px;}
-    body.dark{background:#020307;color:var(--text);}
-    a{color:inherit;}
-    button{cursor:pointer;border:none;background:var(--surface-soft);color:var(--text);border-radius:18px;padding:12px 16px;font-weight:700;transition:transform .18s ease,box-shadow .18s ease,background .18s ease;}
+    a{color:inherit;text-decoration:none;}
+    button{cursor:pointer;border:1px solid rgba(255,255,255,0.12);background:var(--surface-soft);color:var(--text);border-radius:10px;padding:12px 16px;font-weight:700;transition:background .18s ease,opacity .18s ease;box-shadow:0 0 6px rgba(255,255,255,0.08);}
     button:active{transform:scale(.98);}
     button:disabled{opacity:.45;cursor:not-allowed;}
-    .btn-green{background:linear-gradient(135deg,var(--accent) 0%,var(--accent-strong) 100%);color:#04140d;box-shadow:0 12px 34px var(--accent-dim);}
-    .btn-green:hover{background:linear-gradient(135deg,var(--accent-strong) 0%,var(--accent) 100%);}
-    .btn-blue{background:linear-gradient(135deg,#2dd4ff 0%,#38bdf8 100%);color:#031420;box-shadow:0 12px 34px rgba(45,212,255,.25);}
-    .btn-red{background:linear-gradient(135deg,#ff5d75 0%,#ff3b5f 100%);color:#2b040b;box-shadow:0 12px 34px rgba(255,61,110,.28);}
-    .btn-ghost{background:transparent;color:var(--text);border:1px solid var(--border);}
-    input[type="text"],input[type="number"],select,textarea{width:100%;padding:14px 16px;border-radius:18px;border:1px solid rgba(255,255,255,0.05);background:var(--surface);color:var(--text);outline:none;transition:border .18s ease,box-shadow .18s ease;}
-    input:focus,select:focus,textarea:focus{border-color:var(--accent);box-shadow:0 0 0 3px var(--accent-dim);}
+    .btn-green{background:linear-gradient(135deg,var(--accent),var(--accent-strong));color:#04140d;}
+    .btn-blue{background:linear-gradient(135deg,#2dd4ff,#38bdf8);color:#031420;}
+    .btn-red{background:linear-gradient(135deg,#ff5d75,#ff3b5f);color:#2b040b;}
+    .btn-ghost{background:transparent;color:var(--text);}
+    input[type="text"],input[type="number"],select,textarea{width:100%;padding:12px 14px;border-radius:10px;border:1px solid rgba(255,255,255,0.12);background:rgba(12,18,28,0.82);color:var(--text);outline:none;transition:border-color .18s ease,box-shadow .18s ease;box-shadow:0 0 6px rgba(255,255,255,0.08);}
+    input:focus,select:focus,textarea:focus{border-color:var(--accent);}
     textarea{min-height:130px;resize:vertical;line-height:1.6;}
-    label.small{font-size:12px;color:var(--muted);display:block;margin-bottom:6px;}
-    .app-shell{width:100%;max-width:460px;padding:26px 18px 36px;display:flex;flex-direction:column;gap:18px;position:relative;}
-    @media(min-width:520px){.app-shell{max-width:520px;}}
-    .app-header{display:flex;align-items:center;gap:14px;}
-    .hamburger{width:46px;height:46px;display:inline-flex;align-items:center;justify-content:center;border-radius:16px;background:var(--surface-strong);border:1px solid var(--border);color:var(--accent);box-shadow:0 10px 26px rgba(18,233,153,.18);}
-    .header-meta{margin-inline-start:auto;display:flex;flex-wrap:wrap;align-items:stretch;justify-content:flex-end;gap:14px;flex:1 1 auto;}
-    .counter-cluster{display:flex;align-items:center;justify-content:center;gap:12px;background:var(--surface-strong);padding:10px 14px;border-radius:18px;border:1px solid var(--border);box-shadow:0 12px 30px rgba(16,26,44,.36);flex-wrap:wrap;}
-    .counter-mini{display:flex;flex-direction:column;align-items:center;justify-content:center;min-width:86px;padding:4px 0;flex:1 1 80px;}
-    .counter-mini .label{font-size:11px;color:var(--muted);letter-spacing:.4px;}
-    .counter-mini .value{font-size:16px;font-weight:800;color:var(--accent);}
-    .section-chip{display:flex;align-items:center;gap:6px;padding:6px 12px;border-radius:999px;border:1px solid rgba(43,255,168,.26);background:rgba(43,255,168,.08);color:var(--accent);font-weight:700;white-space:nowrap;flex:0 0 auto;transition:background .18s ease,border .18s ease,color .18s ease;}
-    .section-chip .chip-label{font-size:11px;letter-spacing:.3px;color:var(--muted);}
-    .section-chip .chip-value{color:var(--text-strong);font-size:13px;}
-    .section-chip.is-empty{background:rgba(255,255,255,.04);border-color:rgba(255,255,255,.08);color:var(--muted);}
-    .section-chip.is-empty .chip-value{color:var(--muted);}
-    .view-switch{display:flex;gap:10px;}
-    .view-tab{flex:1;background:var(--surface);border:1px solid transparent;border-radius:16px;padding:12px 14px;color:var(--muted);font-weight:700;}
-    .view-tab.active{background:linear-gradient(135deg,var(--surface-strong),#1c2537);color:var(--accent);border-color:rgba(43,255,168,.22);box-shadow:0 12px 32px rgba(26,214,145,.22);}
-    .view-panel{display:none;flex-direction:column;gap:16px;}
+    .layout{width:100%;max-width:1080px;display:flex;flex-direction:column;gap:24px;}
+    .main-area{display:flex;flex-direction:column;gap:16px;}
+    .top-bar{display:flex;align-items:center;gap:12px;}
+    .hamburger{width:46px;height:46px;display:flex;align-items:center;justify-content:center;}
+    .header-meta{margin-inline-start:auto;display:flex;align-items:center;gap:12px;flex-wrap:wrap;}
+    .counter-cluster{display:flex;gap:8px;}
+    .counter-mini{display:flex;align-items:center;justify-content:center;min-width:62px;height:46px;border:1px solid rgba(255,255,255,0.12);border-radius:10px;box-shadow:0 0 6px rgba(255,255,255,0.08);padding:0 12px;font-weight:700;}
+    .counter-mini .value{font-size:16px;color:var(--accent);}
+    .section-chip{display:flex;align-items:center;justify-content:center;min-height:46px;min-width:120px;padding:0 18px;border-radius:999px;border:1px solid rgba(255,255,255,0.18);box-shadow:0 0 6px rgba(255,255,255,0.08);}
+    .section-chip.is-empty{opacity:.55;}
+    .chip-value{font-weight:700;color:var(--text-strong);}
+    .view-switch{display:flex;gap:8px;}
+    .view-tab{flex:1;background:transparent;border:1px solid rgba(255,255,255,0.12);border-radius:10px;padding:12px 14px;color:var(--muted);font-weight:700;box-shadow:0 0 6px rgba(255,255,255,0.08);}
+    .view-tab.active{color:var(--accent);border-color:var(--accent);}
+    .view-panel{display:none;flex-direction:column;gap:0;margin:0;padding:0;}
     .view-panel.active{display:flex;}
-    .stack-group{background:linear-gradient(150deg,rgba(18,26,38,.96),rgba(8,12,22,.9));border-radius:30px;border:1px solid rgba(255,255,255,.05);box-shadow:0 28px 72px rgba(5,12,22,.55);display:flex;flex-direction:column;overflow:hidden;}
-    .stack-row{padding:24px 26px;border-bottom:1px solid rgba(255,255,255,.04);display:flex;flex-direction:column;gap:18px;}
-    .stack-row:last-child{border-bottom:none;}
-    .stack-row--title{padding:30px 28px 18px;gap:10px;}
-    .stack-row--primary{padding:0;border-bottom:none;}
-    .primary-blocks{display:flex;flex-direction:column;gap:0;}
-    .primary-block{display:flex;flex-direction:column;gap:16px;padding:24px 28px;}
-    .primary-block + .primary-block{padding-top:0;}
-    .primary-block:not(:last-child){padding-bottom:0;}
-    .stack-title{margin:0;font-size:24px;font-weight:800;color:var(--accent);letter-spacing:.6px;}
-    .stack-subtitle{margin:0;font-size:13px;color:var(--muted);letter-spacing:.4px;}
-    .stack-box{display:flex;flex-direction:column;gap:18px;}
-    .log-slot{display:flex;flex-direction:column;gap:12px;}
-    .mobile-load-spot{display:none;}
-    .mobile-load-spot.show{display:block;}
-    .mobile-load-spot #loadCard{margin-top:18px;}
-    #logSlot > *{width:100%;}
-    .card{background:linear-gradient(145deg,var(--surface-strong),rgba(10,18,32,.96));border-radius:26px;padding:20px;border:1px solid rgba(255,255,255,.06);box-shadow:0 22px 50px rgba(5,12,22,.58);backdrop-filter:blur(6px);}
-    .card.flat{background:linear-gradient(150deg,rgba(18,26,38,.96),rgba(8,12,22,.92));border-color:rgba(255,255,255,.04);box-shadow:0 18px 42px rgba(6,10,20,.45);}
-    #loadCard{display:flex;flex-direction:column;gap:12px;background:var(--surface-strong);border-radius:22px;padding:18px;border:1px solid rgba(255,255,255,0.08);box-shadow:0 18px 42px rgba(6,10,20,.45);width:100%;max-width:none;}
-    #loadCard button{width:100%;font-size:15px;}
-    #loadCard .muted{font-size:12px;}
-    .badge{display:inline-flex;align-items:center;justify-content:center;padding:6px 12px;border-radius:999px;font-size:12px;font-weight:700;letter-spacing:.4px;border:1px solid rgba(255,255,255,.08);background:rgba(255,255,255,.04);}
-    .badge--withdraw{color:#4de4a1;border-color:rgba(77,228,161,.32);background:rgba(77,228,161,.09);}
-    .badge--agent{color:#38bdf8;border-color:rgba(56,189,248,.28);background:rgba(56,189,248,.08);}
-    .badge--admin{color:#facc15;border-color:rgba(250,204,21,.32);background:rgba(250,204,21,.08);}
-    .badge--dup{color:#ff5d75;border-color:rgba(255,93,117,.34);background:rgba(255,93,117,.12);}
-    .badge--loading{color:var(--muted);border-color:rgba(255,255,255,.08);}
-    #nameText{font-size:15px;color:var(--muted);margin-bottom:8px;}
-    #amountText{font-size:64px;font-weight:900;color:var(--accent);text-shadow:0 0 24px rgba(43,255,168,.45);margin-bottom:8px;}
-    #discountInfo{font-size:13px;color:var(--muted);margin-bottom:6px;min-height:18px;}
-    #multiText{font-size:12px;color:var(--muted);letter-spacing:.4px;}
-    #extraDupInfo{font-size:12px;color:var(--muted);margin-top:12px;}
-    .row{display:flex;align-items:center;gap:12px;flex-wrap:wrap;}
-    .primary-cluster{display:flex;flex-direction:column;gap:18px;width:100%;}
-    .column{display:flex;flex-direction:column;gap:12px;}
-    .column.stretch>*{width:100%;}
-    .row.stretch>*,.row.stretch>button{flex:1 1 auto;}
-    .pill-group{display:flex;gap:10px;flex-wrap:wrap;}
-    .pill{flex:1;min-width:120px;background:var(--surface);padding:12px 14px;border-radius:18px;border:1px solid rgba(255,255,255,.04);display:flex;flex-direction:column;gap:6px;}
-    .pill .title{font-size:12px;color:var(--muted);}
-    .pill .value{font-weight:700;font-size:15px;color:var(--text);}
-    #resultsBox{padding:26px 22px;text-align:center;background:radial-gradient(circle at top,#1a2e2a 0%,#0b1118 55%,#090d13 100%);border:1px solid rgba(43,255,168,.22);box-shadow:0 28px 70px rgba(30,255,168,.18);display:flex;flex-direction:column;gap:12px;justify-content:center;border-radius:26px;}
-    #resultsBox .badges{display:flex;justify-content:center;gap:8px;flex-wrap:wrap;margin-bottom:0;}
-    #searchCard{background:linear-gradient(160deg,rgba(18,26,38,.94),rgba(7,12,22,.88));border-radius:22px;box-shadow:0 18px 42px rgba(6,10,20,.4);border:1px solid rgba(255,255,255,.05);display:flex;flex-direction:column;gap:16px;padding:22px 20px;}
-    #searchCard button{min-width:160px;}
-    #searchCard .column button{width:100%;}
-    #searchCard .actions{display:flex;justify-content:space-between;gap:12px;align-items:center;margin-top:8px;}
-    #searchCard .actions .muted{flex:1;}
-    #advCard{background:linear-gradient(160deg,rgba(18,26,38,.96),rgba(7,10,20,.9));border-radius:26px;border:1px solid rgba(255,255,255,.06);box-shadow:0 22px 50px rgba(5,12,22,.48);display:flex;flex-direction:column;gap:24px;padding:28px;}
-    #advCard .row{gap:10px;}
-    #advCard select{background:var(--surface-strong);}
-    #advCard .btn-ghost{border-color:rgba(43,255,168,.26);color:var(--accent);min-width:110px;}
-    #advCard .btn-green{padding:16px;font-size:18px;border-radius:20px;}
-    #advCard .adv-top{display:flex;flex-direction:column;gap:12px;}
-    #advCard .adv-control-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:12px;}
-    #advCard .adv-control{display:flex;flex-direction:column;gap:8px;padding:12px;border-radius:18px;background:rgba(255,255,255,.02);border:1px solid rgba(255,255,255,.04);backdrop-filter:blur(4px);}
-    #advCard .adv-control select{width:100%;min-height:44px;}
-    #advCard .adv-control--color{align-items:center;justify-content:center;}
-    #advCard .adv-control--color input[type="color"]{width:100%;height:48px;border-radius:14px;border:1px solid rgba(255,255,255,.08);background:var(--surface-strong);padding:0;}
-    #advCard .toggle-chip{display:none;}
-    #advCard .toggles-row{display:none;}
-    #discountInput,#applyDiscountToMessage,#enableSalaryCorrection{display:none;}
-    .adv-subcard{background:rgba(255,255,255,.02);border:1px solid rgba(255,255,255,.05);border-radius:20px;padding:18px;display:flex;flex-direction:column;gap:12px;}
-    #personCard{display:none;}
-    #bulkCard{display:flex;flex-direction:column;gap:24px;background:rgba(255,255,255,.02);border:1px solid rgba(255,255,255,.05);border-radius:22px;padding:22px;}
-    .bulk-actions-row{display:flex;flex-wrap:wrap;gap:12px;}
+    #resultsBox{display:flex;flex-direction:column;gap:12px;padding:12px 0;}
+    #resultsBox .badges{display:flex;gap:6px;flex-wrap:wrap;align-items:center;}
+    .badge{display:inline-flex;align-items:center;justify-content:center;padding:6px 12px;border-radius:999px;font-size:12px;font-weight:700;border:1px solid rgba(255,255,255,0.12);box-shadow:0 0 6px rgba(255,255,255,0.08);}
+    .badge--withdraw{color:#4de4a1;}
+    .badge--agent{color:#38bdf8;}
+    .badge--admin{color:#facc15;}
+    .badge--dup{color:#ff5d75;}
+    .badge--loading{color:var(--muted);}
+    #statusChipsRow{display:flex;flex-wrap:wrap;gap:6px;}
+    #nameText{font-size:15px;color:var(--muted);}
+    #amountText{font-size:56px;font-weight:900;color:var(--accent);}
+    #discountInfo{font-size:13px;color:var(--muted);min-height:18px;}
+    #multiText{font-size:12px;color:var(--muted);}
+    #extraDupInfo{font-size:12px;color:var(--muted);}
+    .search-flow{display:flex;flex-direction:column;gap:6px;}
+    .search-row{display:flex;gap:8px;align-items:center;}
+    .search-row input{flex:1;}
+    .search-row button{flex:0 0 auto;}
+    .search-meta{display:flex;gap:12px;align-items:center;}
+    #pasteHint{flex:1;color:var(--muted);}
+    #lastIdPill{margin-inline-start:auto;}
+    .single-flow{display:flex;flex-direction:column;gap:12px;padding:12px 0;}
+    .single-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:8px;}
+    .create-row{display:flex;gap:8px;}
+    .create-row input{flex:1;}
+    .person-card{display:flex;flex-direction:column;gap:8px;padding:12px;border:1px solid rgba(255,255,255,0.12);border-radius:10px;box-shadow:0 0 6px rgba(255,255,255,0.08);}
+    .person-header{display:flex;justify-content:flex-end;gap:8px;}
+    .log-slot{display:flex;flex-direction:column;gap:8px;padding:12px 0;}
+    #aiMountHere{display:flex;flex-direction:column;gap:12px;padding:12px 0;}
+    .bulk-note{color:var(--muted);padding:12px 0;}
+    .bulk-config{display:flex;flex-direction:column;gap:8px;padding:12px 0;}
+    .bulk-target-row{display:flex;gap:8px;align-items:center;}
+    .bulk-inline{display:flex;gap:8px;flex-wrap:wrap;align-items:center;}
+    .bulk-inline input{flex:1 1 200px;}
+    .bulk-new-inline{flex-wrap:nowrap;align-items:center;}
+    .bulk-new-inline input{flex:1 1 auto;min-width:0;}
+    .bulk-external{display:flex;flex-direction:column;gap:8px;padding:12px 0;}
+    .bulk-colors{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:8px;}
+    .bulk-actions-row{display:flex;flex-wrap:wrap;gap:8px;padding:12px 0;}
     .bulk-actions-row button{flex:1 1 160px;}
-    .bulk-progress-wrap{display:flex;flex-direction:column;gap:12px;}
-    .bulk-progress{height:10px;background:rgba(255,255,255,.08);border-radius:999px;overflow:hidden;}
+    .bulk-progress-wrap{display:flex;flex-direction:column;gap:6px;padding:12px 0;}
+    .bulk-progress{height:10px;background:rgba(255,255,255,0.12);border-radius:999px;overflow:hidden;}
     .bulk-progress-bar{height:100%;width:0;background:linear-gradient(90deg,var(--accent),#38bdf8);transition:width .3s ease;}
-    .bulk-progress-text{display:flex;justify-content:space-between;align-items:center;gap:12px;color:var(--muted);font-size:13px;}
-    .bulk-progress-text span:first-child{color:var(--accent);font-weight:800;}
-    .bulk-counters{display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:12px;}
-    .bulk-counter{background:rgba(255,255,255,.02);border:1px solid rgba(255,255,255,.05);border-radius:16px;padding:12px 14px;font-size:12px;color:var(--muted);}
-    .bulk-counter b{color:var(--text-strong);}
-    #bulkIds{min-height:220px;background:var(--surface-strong);border-radius:20px;border:1px solid rgba(255,255,255,.08);padding:18px;color:var(--text);box-shadow:0 16px 38px rgba(6,10,20,.4);}
-    .bulk-table-wrap{display:flex;flex-direction:column;gap:14px;padding:18px;border-radius:20px;background:rgba(255,255,255,.02);border:1px solid rgba(255,255,255,.05);}
-    .bulk-table{width:100%;border-collapse:collapse;font-size:13px;border-radius:16px;overflow:hidden;}
-    .bulk-table thead{background:var(--surface-strong);}
-    .bulk-table th,.bulk-table td{padding:10px;border-bottom:1px solid rgba(255,255,255,.05);text-align:right;}
-    .bulk-table tbody tr:nth-child(even){background:rgba(255,255,255,.02);}
-    .bulk-page-btn{background:var(--surface-strong);color:var(--text);border:1px solid rgba(255,255,255,.08);border-radius:14px;padding:10px 18px;}
-    .bulk-config{display:flex;flex-direction:column;gap:20px;background:rgba(255,255,255,.02);border:1px solid rgba(255,255,255,.05);border-radius:22px;padding:22px;}
-    .bulk-config-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:14px;}
-    .bulk-config-block{background:rgba(255,255,255,.02);border:1px solid rgba(255,255,255,.04);border-radius:18px;padding:16px;display:flex;flex-direction:column;gap:12px;}
-    .bulk-inline{display:flex;gap:12px;flex-wrap:wrap;}
-    .bulk-inline input{min-width:200px;}
-    .bulk-external{display:flex;flex-direction:column;gap:10px;padding:18px;border-radius:18px;background:rgba(255,255,255,.02);border:1px solid rgba(255,255,255,.05);}
-    .bulk-discount-row{display:flex;align-items:center;gap:14px;flex-wrap:wrap;padding:14px 16px;border-radius:18px;background:rgba(255,255,255,.02);border:1px solid rgba(255,255,255,.05);}
-    .drawer-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.55);opacity:0;pointer-events:none;transition:opacity .2s ease;z-index:8;}
+    .bulk-progress-text{display:flex;justify-content:space-between;gap:8px;color:var(--muted);font-size:13px;}
+    .bulk-counters{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:8px;padding:12px 0;}
+    .bulk-counter{border:1px solid rgba(255,255,255,0.12);border-radius:10px;padding:10px;box-shadow:0 0 6px rgba(255,255,255,0.08);font-size:12px;color:var(--muted);}
+    #bulkIds{min-height:220px;}
+    .bulk-table-wrap{display:flex;flex-direction:column;gap:8px;padding:12px 0;}
+    .bulk-table{width:100%;border-collapse:collapse;font-size:13px;}
+    .bulk-table th,.bulk-table td{padding:10px;border-bottom:1px solid rgba(255,255,255,0.12);text-align:right;}
+    .bulk-table thead{background:rgba(255,255,255,0.04);}
+    .bulk-pagination{display:flex;justify-content:space-between;align-items:center;gap:8px;flex-wrap:wrap;}
+    .bulk-page-btn{flex:0 0 auto;}
+    .bulk-page-info{color:var(--muted);font-size:12px;}
+    .bulk-chip{display:inline-flex;align-items:center;padding:2px 8px;border-radius:999px;border:1px solid rgba(255,255,255,0.12);margin-inline-start:6px;font-size:11px;}
+    td.state-cell{display:flex;align-items:center;gap:6px;}
+    .drawer-backdrop{position:fixed;inset:0;background:rgba(0,0,0,0.55);opacity:0;pointer-events:none;transition:opacity .2s ease;z-index:8;}
     .drawer-backdrop.show{opacity:1;pointer-events:auto;}
-    #quickTools.drawer{position:fixed;top:40px;left:50%;transform:translate(-50%,-20px) scale(.96);width:90%;max-width:360px;background:var(--surface-strong);border:1px solid rgba(255,255,255,.08);border-radius:24px;padding:20px 18px;box-shadow:0 30px 80px rgba(0,0,0,.55);opacity:0;pointer-events:none;transition:opacity .2s ease,transform .22s ease;z-index:9;}
-    #quickTools.drawer.open{opacity:1;pointer-events:auto;transform:translate(-50%,0) scale(1);}
-    .drawer-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:18px;}
-    .drawer-title{font-size:18px;font-weight:800;color:var(--text);}
-    .drawer-close{background:transparent;border:1px solid rgba(255,255,255,.12);color:var(--muted);width:38px;height:38px;border-radius:14px;}
-    .drawer-items{display:flex;flex-direction:column;gap:12px;}
-    .drawer-item{background:var(--surface);border-radius:18px;padding:14px 16px;text-align:center;font-weight:700;letter-spacing:.4px;border:1px solid rgba(255,255,255,.04);color:var(--text);}
-    .drawer-item.primary{background:linear-gradient(135deg,var(--accent),var(--accent-strong));color:#04140d;box-shadow:0 14px 38px var(--accent-dim);}
-    .drawer-toggle{display:flex;align-items:center;justify-content:space-between;background:var(--surface);border-radius:18px;padding:12px 16px;border:1px solid rgba(255,255,255,.04);}
-    .drawer-section{margin-top:12px;padding:14px 16px;border-radius:18px;background:var(--surface);border:1px solid rgba(255,255,255,.04);display:flex;flex-direction:column;gap:10px;}
-    .drawer-section .small{margin:0;}
-    .drawer-discount-row{display:flex;align-items:center;gap:10px;}
+    #quickTools{position:fixed;top:24px;left:50%;transform:translateX(-50%);width:92%;max-width:360px;background:rgba(12,18,28,0.94);border:1px solid rgba(255,255,255,0.12);border-radius:16px;padding:16px;display:flex;flex-direction:column;gap:12px;z-index:9;opacity:0;pointer-events:none;transition:opacity .2s ease,transform .2s ease;}
+    #quickTools.open{opacity:1;pointer-events:auto;transform:translate(-50%,0);}
+    .drawer-header{display:flex;justify-content:flex-end;}
+    #drawerClose{width:38px;height:38px;display:flex;align-items:center;justify-content:center;}
+    .menu-stats{display:flex;gap:8px;flex-wrap:wrap;}
+    .menu-counter{flex:1 1 120px;display:flex;align-items:center;justify-content:center;border:1px solid rgba(255,255,255,0.12);border-radius:10px;box-shadow:0 0 6px rgba(255,255,255,0.08);padding:10px;font-weight:700;}
+    #menuSectionChip{display:flex;align-items:center;justify-content:center;border:1px solid rgba(255,255,255,0.18);border-radius:999px;min-height:46px;box-shadow:0 0 6px rgba(255,255,255,0.08);}
+    #menuSectionChip.is-empty{opacity:.55;}
+    #loadCard{display:flex;flex-direction:column;gap:8px;}
+    #loadNote{color:var(--muted);font-size:12px;}
+    .menu-actions{display:flex;flex-direction:column;gap:8px;}
+    .menu-btn{width:100%;border:1px solid rgba(255,255,255,0.12);border-radius:10px;background:transparent;color:var(--text);padding:12px 16px;font-weight:700;box-shadow:0 0 6px rgba(255,255,255,0.08);}
+    .menu-section{display:flex;flex-direction:column;gap:8px;}
+    .menu-toggle{display:flex;justify-content:flex-end;}
+    .drawer-discount-row{display:flex;gap:8px;align-items:center;}
     .drawer-discount-row input{flex:1;}
-    .drawer-discount-value{min-width:90px;text-align:center;color:var(--muted);font-size:13px;font-weight:700;padding:10px 12px;border-radius:14px;background:var(--surface-strong);border:1px solid rgba(255,255,255,.06);}
+    .drawer-discount-value{min-width:90px;text-align:center;color:var(--muted);font-size:13px;font-weight:700;padding:10px 12px;border-radius:10px;border:1px solid rgba(255,255,255,0.12);box-shadow:0 0 6px rgba(255,255,255,0.08);}
     .drawer-note{font-size:12px;color:var(--muted);line-height:1.5;}
-    #qtMode{width:58px;height:30px;border-radius:999px;background:var(--surface-strong);position:relative;border:1px solid rgba(255,255,255,.12);padding:0;font-size:0;line-height:0;}
-    #qtMode::after{content:'';position:absolute;top:3px;right:3px;width:24px;height:24px;border-radius:50%;background:#fff;box-shadow:0 2px 10px rgba(0,0,0,.35);transition:transform .2s ease,background .2s ease;}
-    body.dark #qtMode{background:var(--accent);border-color:rgba(43,255,168,.32);}
+    #qtMode{width:58px;height:30px;border-radius:999px;background:var(--surface-soft);position:relative;border:1px solid rgba(255,255,255,0.18);padding:0;font-size:0;line-height:0;box-shadow:0 0 6px rgba(255,255,255,0.08);}
+    #qtMode::after{content:'';position:absolute;top:3px;right:3px;width:24px;height:24px;border-radius:50%;background:#fff;transition:transform .2s ease,background .2s ease;}
+    body.dark #qtMode{background:var(--accent);border-color:rgba(43,255,168,0.32);}
     body.dark #qtMode::after{transform:translateX(-26px);background:#052016;}
     .hidden-tools{display:none;}
-    .muted{color:var(--muted);}
-    .lastid{display:inline-flex;align-items:center;gap:6px;padding:6px 10px;border-radius:999px;border:1px solid rgba(255,255,255,.08);color:var(--muted);cursor:pointer;background:var(--surface-strong);font-size:12px;}
-    #lastIdPill{margin-inline-start:auto;}
-    #bulkCard .bulk-chip{background:rgba(255,93,117,.16);color:#ff8da4;border-radius:999px;padding:2px 8px;font-size:11px;}
-    .bulk-pagination{display:flex;justify-content:space-between;align-items:center;gap:14px;margin-top:12px;flex-wrap:wrap;}
-    .bulk-page-info{color:var(--muted);font-size:12px;}
-    #bulkStatusText{font-size:13px;}
-    #pasteHint{color:var(--muted);}
-    #advNote{color:var(--muted);font-size:13px;}
-    #loadNote{margin-top:8px;color:var(--muted);font-size:12px;}
-    #statusChipsRow{display:flex;flex-wrap:wrap;gap:6px;justify-content:center;}
-    #statusChipsRow .chip{padding:4px 10px;border-radius:999px;background:rgba(255,255,255,.05);font-size:11px;color:var(--muted);}
-    .view-panel footer{margin-top:8px;font-size:12px;color:var(--muted);text-align:center;}
-
-    #advCard .adv-control .title{display:none;}
-    @media(max-width:768px){
-      #advCard .adv-control{gap:6px;padding:12px;}
-      #advCard .adv-control--color input[type="color"]{height:52px;}
-    }
-
+    .muted{color:var(--muted);font-size:12px;}
+    .lastid{display:inline-flex;align-items:center;gap:6px;padding:6px 10px;border-radius:999px;border:1px solid rgba(255,255,255,0.12);color:var(--muted);cursor:pointer;box-shadow:0 0 6px rgba(255,255,255,0.08);font-size:12px;}
     @media(min-width:1024px){
-      body{padding:0;align-items:stretch;}
-      .app-shell{max-width:none;width:100%;padding:46px clamp(32px,5vw,72px);gap:32px;min-height:100vh;}
-      .view-switch{max-width:960px;margin:0 auto;width:100%;}
-      .view-tab{max-width:240px;}
-      #mainView .stack-group,#bulkView .stack-group{max-width:960px;margin:0 auto;}
-      .stack-row{padding-inline:36px;}
-      .stack-row--title{padding-inline:40px;padding-top:36px;}
-      #advCard .adv-control-grid{grid-template-columns:repeat(2,minmax(0,1fr));gap:16px;}
-      .bulk-actions-row button{flex:1 1 180px;}
-      #bulkIds{min-height:260px;}
+      body{padding:48px;}
+      .layout{flex-direction:row;align-items:flex-start;gap:32px;}
+      #quickTools{position:sticky;top:0;left:auto;transform:none;width:280px;max-width:none;opacity:1;pointer-events:auto;}
+      #drawerBackdrop{display:none;}
+      .drawer-header{display:none;}
+    }
+    @media(max-width:768px){
+      body{padding:16px 10px;}
+      button,input[type="text"],input[type="number"],select,textarea{width:100%;font-size:16px;border-radius:10px;}
+      .search-row{flex-direction:column;align-items:stretch;}
+      .search-row button{width:100%;}
+      .search-meta{flex-direction:column;align-items:flex-end;gap:4px;}
+      .create-row{flex-direction:column;}
+      .bulk-target-row{flex-direction:column;align-items:stretch;}
+      .bulk-inline{flex-direction:column;}
+      .bulk-new-inline{flex-direction:row;flex-wrap:nowrap;}
+      .bulk-new-inline input{max-width:65vw;}
+      .bulk-new-inline button{width:auto;flex:0 0 auto;}
+      .bulk-actions-row button{flex:1;}
+      #quickTools{top:16px;}
     }
   </style>
+
 </head>
+
+
 <body class="dark">
-  <div class="app-shell">
-    <header class="app-header">
-      <button id="menuToggle" class="hamburger" type="button" aria-label="فتح القائمة">
-        <svg width="22" height="18" viewBox="0 0 22 18" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-          <rect x="1" y="1" width="20" height="2.4" rx="1.2" fill="currentColor" />
-          <rect x="1" y="7.8" width="20" height="2.4" rx="1.2" fill="currentColor" />
-          <rect x="1" y="14.6" width="20" height="2.4" rx="1.2" fill="currentColor" />
-        </svg>
-      </button>
-      <div class="header-meta">
-        <div class="counter-cluster">
-          <div class="counter-mini">
-            <span class="label">ملوّن</span>
-            <span id="qtColored" class="value">—</span>
-          </div>
-          <div class="counter-mini">
-            <span class="label">غير ملوّن</span>
-            <span id="qtUncolored" class="value">—</span>
-          </div>
+  <div class="layout">
+    <aside id="quickTools" class="drawer" aria-hidden="true">
+      <div class="drawer-header">
+        <button id="drawerClose" type="button" aria-label="إغلاق">✕</button>
+      </div>
+      <div class="menu-stats">
+        <div class="menu-counter" title="ملوّن">
+          <span id="menuQtColored" class="value">—</span>
         </div>
-        <div id="sectionChip" class="section-chip is-empty">
-          <span class="chip-label">القسم</span>
-          <span id="headerSectionLabel" class="chip-value">—</span>
+        <div class="menu-counter" title="غير ملوّن">
+          <span id="menuQtUncolored" class="value">—</span>
         </div>
       </div>
-    </header>
-    <div class="view-switch">
-      <button class="view-tab active" type="button" data-view="main">الصفحة الرئيسية</button>
-      <button class="view-tab" type="button" data-view="bulk">أداة البحث الجماعي</button>
-    </div>
-
-    <div id="mobileLoadCardSpot" class="mobile-load-spot"></div>
-
-    <section id="mainView" class="view-panel active">
-      <div id="mainStack" class="stack-group">
-        <div class="stack-row stack-row--title">
-          <h2 class="stack-title">الصفحة الرئيسية</h2>
-        </div>
-
-        <div class="stack-row stack-row--primary">
-          <div class="primary-blocks">
-            <div class="primary-block primary-block--results">
-              <h3 class="stack-subtitle">خانة النتائج</h3>
-              <div id="resultsBox">
-                <div class="badges">
-                  <span id="statusBadge" class="badge badge--loading">—</span>
-                  <span id="dupBadge" class="badge badge--dup" style="display:none">مكرر</span>
-                  <span id="statusChipsRow"></span>
-                </div>
-                <div id="nameText" class="subline">—</div>
-                <div id="amountText" class="amountBig">—</div>
-                <div id="discountInfo" style="display:none"></div>
-                <div id="multiText" class="subline"></div>
-                <div id="extraDupInfo" class="muted" style="margin-top:12px"></div>
-              </div>
-            </div>
-
-            <div class="primary-block primary-block--search">
-              <h3 class="stack-subtitle">خانة البحث</h3>
-              <div id="searchCard">
-                <label class="small">ID للبحث</label>
-                <div class="column stretch">
-                  <input id="idInput" type="text" placeholder="أدخل ID هنا" autocomplete="off" inputmode="numeric">
-                  <button id="pasteSearchBtn" class="btn-blue" type="button">لصق ثم بحث</button>
-                </div>
-                <div class="actions">
-                  <div id="pasteHint" class="muted"></div>
-                  <div id="lastIdPill" class="lastid" style="display:none">آخر ID: <b id="lastIdText"></b></div>
-                </div>
-              </div>
-            </div>
-
-            <div class="primary-block primary-block--single">
-              <h3 class="stack-subtitle">قسم التنفيذ الفردي</h3>
-              <div id="advCard">
-                <div class="adv-top">
-                  <button id="advRunBtn" class="btn-green" type="button">تنفيذ (حسب النتيجة)</button>
-                  <div id="advNote" class="muted"></div>
-                </div>
-
-                <div class="adv-control-grid">
-                  <div class="pill adv-control">
-                    <span class="title">الهدف</span>
-                    <select id="sheetSelect" aria-label="الهدف"></select>
-                  </div>
-                  <div class="pill adv-control">
-                    <span class="title">التنفيذ</span>
-                    <select id="targetMode" aria-label="وضع التنفيذ">
-                      <option value="agent">الوكيل فقط</option>
-                      <option value="both" selected>الإدارة + الوكيل</option>
-                    </select>
-                  </div>
-                  <div class="pill adv-control adv-control--color">
-                    <span class="title">لون الإدارة</span>
-                    <input id="adminColor" type="color" value="#fde68a" aria-label="لون الإدارة">
-                  </div>
-                  <div class="pill adv-control adv-control--color">
-                    <span class="title">لون سحب وكالة</span>
-                    <input id="withdrawColor" type="color" value="#9629ff" aria-label="لون سحب وكالة">
-                  </div>
-                </div>
-
-                <div class="row stretch">
-                  <input id="newSheetName" type="text" placeholder="اسم ورقة جديدة (داخل الإدارة)">
-                  <button id="createSheetBtn" class="btn-ghost" type="button">إنشاء</button>
-                </div>
-
-                <div class="row toggles-row">
-                  <div class="row" style="gap:8px;align-items:center;">
-                    <label class="small" style="margin:0;">الخصم %</label>
-                    <input id="discountInput" type="number" min="0" max="100" value="0" step="1" style="width:110px">
-                  </div>
-                  <div class="toggle-chip">
-                    <span class="switch-label">الخصم لحظيًا</span>
-                    <label class="ios-toggle">
-                      <input id="applyDiscountToMessage" type="checkbox">
-                      <span class="slider"></span>
-                    </label>
-                  </div>
-                  <div class="toggle-chip">
-                    <span class="switch-label">تصحيح الراتب</span>
-                    <label class="ios-toggle">
-                      <input id="enableSalaryCorrection" type="checkbox">
-                      <span class="slider"></span>
-                    </label>
-                  </div>
-                </div>
-
-                <div class="adv-subcard" id="personCard">
-                  <div class="row" style="justify-content:space-between; align-items:center">
-                    <strong>بيانات صاحب الـID</strong>
-                    <div class="row" style="gap:6px; flex:0 0 auto">
-                      <button id="copyMsgBtn" class="btn-green" type="button">نسخ الرسالة</button>
-                      <button id="colorAllBtn" class="btn-ghost" type="button" title="تلوين كل الـIDs لهذا الشخص بسرعة">تلوين الكل</button>
-                    </div>
-                  </div>
-                  <div id="personNote" class="muted" style="margin-top:6px">—</div>
-                  <textarea id="personMsg" rows="8" style="margin-top:8px;" readonly></textarea>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div class="stack-row stack-row--log">
-          <h3 class="stack-subtitle">زر السجل</h3>
-          <div class="stack-box">
-            <div id="logSlot" class="log-slot"></div>
-          </div>
-        </div>
-
-        <div class="stack-row stack-row--load">
-          <h3 class="stack-subtitle">تحميل البيانات</h3>
-          <div class="stack-box">
-            <div class="load-card" id="loadCard">
-              <button id="reloadBtn" class="btn-red" type="button">تحميل البيانات</button>
-              <div id="loadNote" class="muted"></div>
-            </div>
-          </div>
-        </div>
+      <div id="menuSectionChip" class="section-chip is-empty" title="القسم">
+        <span id="menuSectionLabel" class="chip-value">—</span>
       </div>
-
-      <div id="bulkMobileMount" class="span2" style="display:none"></div>
-    </section>
-
-    <section id="bulkView" class="view-panel">
-      <div id="bulkStack" class="stack-group">
-        <div class="stack-row stack-row--title">
-          <h2 class="stack-title">أداة البحث الجماعي</h2>
-        </div>
-
-        <div class="stack-row stack-row--goal">
-          <h3 class="stack-subtitle">قسم الهدف و المنطق</h3>
-          <div class="stack-box">
-            <div class="bulk-note" id="bulkStatusText">ألصق IDs وسيتم التحليل تلقائيًا.</div>
-            <div id="bulkConfigCard" class="bulk-config">
-              <div class="bulk-config-grid">
-                <div class="bulk-config-block">
-                  <label class="small">النطاق</label>
-                  <select id="bulkScope">
-                    <option value="agent">الوكيل فقط</option>
-                    <option value="both" selected>الإدارة + الوكيل</option>
-                    <option value="all">الكل (يشمل الخارجي)</option>
-                  </select>
-                </div>
-                <div class="bulk-config-block">
-                  <label class="small">ورقة الهدف</label>
-                  <div class="row" style="gap:6px; align-items:center">
-                    <select id="bulkTargetSheet" style="flex:1"></select>
-                    <button id="bulkRefreshSheets" class="btn-ghost" title="تحديث قائمة الأوراق" style="flex:0 0 auto">↻</button>
-                  </div>
-                </div>
-              </div>
-
-              <div class="bulk-inline">
-                <input id="bulkNewSheet" type="text" placeholder="اسم ورقة جديدة (داخل الإدارة)">
-                <button id="bulkCreateSheet" class="btn-ghost">إنشاء ورقة</button>
-              </div>
-
-              <div id="bulkExternalWrap" class="bulk-external" style="display:none;">
-                <label class="small" style="display:block">ورقة الهدف (خارجي) <span id="bulkExternalFileLabel" class="muted"></span></label>
-                <div class="row" style="gap:6px; align-items:center">
-                  <select id="bulkExternalTargetSheet" style="flex:1"></select>
-                  <button id="bulkExternalRefreshSheets" class="btn-ghost" title="تحديث قائمة الأوراق الخارجية" style="flex:0 0 auto">↻</button>
-                </div>
-                <div class="row stretch" style="margin-top:8px">
-                  <input id="bulkExternalNewSheet" type="text" placeholder="اسم ورقة جديدة (خارجية)">
-                  <button id="bulkExternalCreateSheet" class="btn-ghost">إنشاء</button>
-                </div>
-                <div id="bulkExternalNote" class="muted" style="margin-top:6px"></div>
-              </div>
-
-              <div class="bulk-discount-row">
-                <div class="row" style="gap:8px;align-items:center;">
-                  <label class="small" style="margin:0;">لون الإدارة</label>
-                  <input id="bulkAdminColor" type="color" value="#fde68a" aria-label="لون الإدارة">
-                </div>
-                <div class="row" style="gap:8px;align-items:center;">
-                  <label class="small" style="margin:0;">لون السحب</label>
-                  <input id="bulkWithdrawColor" type="color" value="#9629ff" aria-label="لون سحب وكالة">
-                </div>
-                <div class="row" style="gap:8px;align-items:center;">
-                  <label class="small" style="margin:0;">الخصم %</label>
-                  <input id="bulkDiscount" type="number" min="0" max="100" value="0" step="1" style="width:110px">
-                </div>
-                <div class="muted" id="bulkDiscountNote">يُطبّق تلقائيًا على النتائج.</div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div class="stack-row stack-row--execute">
-          <h3 class="stack-subtitle">قسم التنفيذ الجماعي</h3>
-          <div class="stack-box">
-            <div id="bulkCard" class="bulk-execute">
-              <div class="bulk-actions-row">
-                <button id="bulkPasteBtn" class="btn-blue">لصق ثم بحث</button>
-                <button id="bulkExecuteBtn" class="btn-red" disabled>تنفيذ الكل</button>
-                <button id="bulkResetBtn" class="btn-ghost">إعادة تعيين</button>
-                <button id="bulkCopyAllBtn" class="btn-ghost" disabled>نسخ الكل</button>
-                <button id="bulkCopySalaryBtn" class="btn-ghost" disabled>نسخ الراتب فقط</button>
-              </div>
-
-              <div class="bulk-progress-wrap">
-                <div class="bulk-progress">
-                  <div id="bulkProgressBar" class="bulk-progress-bar"></div>
-                </div>
-                <div class="bulk-progress-text">
-                  <span id="bulkProgressLabel">0%</span>
-                  <span id="bulkSummaryText"></span>
-                </div>
-              </div>
-
-              <div class="bulk-counters">
-                <div class="bulk-counter">عدد الإدخالات: <b id="bulkCountTotal">0</b></div>
-                <div class="bulk-counter">ملوّن: <b id="bulkCountColored">0</b></div>
-                <div class="bulk-counter">غير ملوّن: <b id="bulkCountUncolored">0</b></div>
-                <div class="bulk-counter">مجموع الرواتب: <b id="bulkSalarySum">0</b></div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div class="stack-row stack-row--paste">
-          <h3 class="stack-subtitle">قسم خانة اللصق</h3>
-          <div class="stack-box">
-            <textarea id="bulkIds" placeholder="ألصق عدة IDs (سطر لكل ID أو مفصولة بمسافات)"></textarea>
-          </div>
-        </div>
-
-        <div class="stack-row stack-row--results">
-          <h3 class="stack-subtitle">قسم النتائج</h3>
-          <div class="stack-box">
-            <div class="bulk-table-wrap">
-              <table class="bulk-table">
-                <thead>
-                  <tr>
-                    <th>#</th>
-                    <th>ID</th>
-                    <th>الراتب</th>
-                    <th>الحالة</th>
-                    <th>ملوّن؟</th>
-                  </tr>
-                </thead>
-                <tbody id="bulkResultsBody"></tbody>
-              </table>
-              <div id="bulkPagination" class="bulk-pagination">
-                <button id="bulkPrevBtn" class="bulk-page-btn">‹ السابق</button>
-                <span id="bulkPageInfo" class="bulk-page-info"></span>
-                <button id="bulkNextBtn" class="bulk-page-btn">التالي ›</button>
-              </div>
-              <div id="bulkEmptyState" class="bulk-empty">لا توجد نتائج بعد.</div>
-            </div>
-          </div>
-        </div>
+      <div id="loadCard">
+        <button id="reloadBtn" class="btn-red" type="button">تحميل البيانات</button>
+        <div id="loadNote"></div>
       </div>
-
-    </section>
-  </div>
-
-  <div id="drawerBackdrop" class="drawer-backdrop"></div>
-  <aside id="quickTools" class="drawer" aria-hidden="true">
-    <div class="drawer-header">
-      <span class="drawer-title">القائمة</span>
-      <button id="drawerClose" class="drawer-close" type="button" aria-label="إغلاق">✕</button>
-    </div>
-    <div class="drawer-items">
-      <button id="menuReload" class="drawer-item primary" type="button">تحميل البيانات</button>
-      <button id="menuHome" class="drawer-item" type="button">الصفحة الرئيسية</button>
-      <button id="menuBulk" class="drawer-item" type="button">أداة البحث الجماعي</button>
-      <button id="refreshSheetsBtn" class="drawer-item" type="button">تحديث قائمة الأوراق</button>
-      <div class="drawer-section">
-        <label class="small" for="menuSection">القسم الحالي</label>
+      <div class="menu-actions">
+        <button id="menuHome" class="menu-btn" type="button">الصفحة الرئيسية</button>
+        <button id="menuBulk" class="menu-btn" type="button">أداة البحث الجماعي</button>
+        <button id="refreshSheetsBtn" class="menu-btn" type="button">تحديث قائمة الأوراق</button>
+        <button id="togglePersonCardBtn" class="menu-btn" type="button">إيقاف بيانات صاحب الـID</button>
+      </div>
+      <div class="menu-section">
         <select id="menuSection"></select>
         <div id="menuSectionStatus" class="drawer-note"></div>
       </div>
-      <div class="drawer-toggle">
-        <span>الوضع الداكن</span>
+      <div class="menu-toggle">
         <button id="qtMode" type="button" aria-label="تبديل الوضع"></button>
       </div>
-      <div class="drawer-section">
-        <label class="small" for="menuDiscount">الخصم الفوري (%)</label>
+      <div class="menu-section">
         <div class="drawer-discount-row">
           <input id="menuDiscount" type="number" min="0" max="100" step="0.1" inputmode="decimal" placeholder="0">
           <span id="menuDiscountValue" class="drawer-discount-value">بدون خصم</span>
         </div>
-        <div class="drawer-note">يُطبّق مباشرة على نتيجة البحث الفردي.</div>
       </div>
-    </div>
-    <div class="hidden-tools">
-      <button id="qtHideLoad" type="button"></button>
-      <button id="qtHidePerson" type="button"></button>
-      <label><input id="qtDisablePerson" type="checkbox"></label>
-      <button id="qtRefreshCnt" type="button"></button>
-    </div>
-  </aside>
+      <div class="hidden-tools">
+        <button id="qtHideLoad" type="button"></button>
+        <button id="qtHidePerson" type="button"></button>
+        <label><input id="qtDisablePerson" type="checkbox"></label>
+        <button id="qtRefreshCnt" type="button"></button>
+      </div>
+    </aside>
 
+    <div class="main-area">
+      <header class="top-bar">
+        <button id="menuToggle" class="hamburger" type="button" aria-label="فتح القائمة">
+          <svg width="22" height="18" viewBox="0 0 22 18" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <rect x="1" y="1" width="20" height="2.4" rx="1.2" fill="currentColor" />
+            <rect x="1" y="7.8" width="20" height="2.4" rx="1.2" fill="currentColor" />
+            <rect x="1" y="14.6" width="20" height="2.4" rx="1.2" fill="currentColor" />
+          </svg>
+        </button>
+        <div class="header-meta">
+          <div class="counter-cluster">
+            <div class="counter-mini" title="ملوّن">
+              <span id="qtColored" class="value">—</span>
+            </div>
+            <div class="counter-mini" title="غير ملوّن">
+              <span id="qtUncolored" class="value">—</span>
+            </div>
+          </div>
+          <div id="sectionChip" class="section-chip is-empty" title="القسم">
+            <span id="headerSectionLabel" class="chip-value">—</span>
+          </div>
+        </div>
+      </header>
+
+      <div class="view-switch">
+        <button class="view-tab active" type="button" data-view="main">الصفحة الرئيسية</button>
+        <button class="view-tab" type="button" data-view="bulk">أداة البحث الجماعي</button>
+      </div>
+
+      <section id="mainView" class="view-panel active">
+        <div id="resultsBox">
+          <div class="badges">
+            <span id="statusBadge" class="badge badge--loading">—</span>
+            <span id="dupBadge" class="badge badge--dup" style="display:none">مكرر</span>
+            <span id="statusChipsRow"></span>
+          </div>
+          <div id="nameText">—</div>
+          <div id="amountText">—</div>
+          <div id="discountInfo" style="display:none"></div>
+          <div id="multiText"></div>
+          <div id="extraDupInfo" class="muted"></div>
+        </div>
+        <div class="search-flow">
+          <div class="search-row">
+            <input id="idInput" type="text" placeholder="أدخل ID هنا" autocomplete="off" inputmode="numeric">
+            <button id="pasteSearchBtn" class="btn-blue" type="button">لصق ثم بحث</button>
+          </div>
+          <div class="search-meta">
+            <div id="pasteHint" class="muted"></div>
+            <div id="lastIdPill" class="lastid" style="display:none">آخر ID: <b id="lastIdText"></b></div>
+          </div>
+        </div>
+        <div class="single-flow">
+          <button id="advRunBtn" class="btn-green" type="button">تنفيذ (حسب النتيجة)</button>
+          <div id="advNote" class="muted"></div>
+          <div class="single-grid">
+            <select id="sheetSelect" aria-label="الهدف"></select>
+            <select id="targetMode" aria-label="وضع التنفيذ">
+              <option value="agent">الوكيل فقط</option>
+              <option value="both" selected>الإدارة + الوكيل</option>
+            </select>
+            <input id="adminColor" type="color" value="#fde68a" aria-label="لون الإدارة">
+            <input id="withdrawColor" type="color" value="#9629ff" aria-label="لون سحب وكالة">
+          </div>
+          <div class="create-row">
+            <input id="newSheetName" type="text" placeholder="اسم ورقة جديدة (داخل الإدارة)">
+            <button id="createSheetBtn" class="btn-ghost" type="button">إنشاء</button>
+          </div>
+          <div id="personCard" class="person-card" style="display:none;">
+            <div class="person-header">
+              <button id="copyMsgBtn" class="btn-green" type="button">نسخ الرسالة</button>
+              <button id="colorAllBtn" class="btn-ghost" type="button" title="تلوين كل الـIDs لهذا الشخص بسرعة">تلوين الكل</button>
+            </div>
+            <div id="personNote" class="muted"></div>
+            <textarea id="personMsg" rows="8" readonly></textarea>
+          </div>
+        </div>
+        <div id="logSlot" class="log-slot"></div>
+        <div id="aiMountHere"></div>
+        <div id="bulkMobileMount" style="display:none"></div>
+      </section>
+
+      <section id="bulkView" class="view-panel">
+        <div id="bulkStatusText" class="bulk-note"></div>
+        <div class="bulk-config">
+          <select id="bulkScope">
+            <option value="agent">الوكيل فقط</option>
+            <option value="both" selected>الإدارة + الوكيل</option>
+            <option value="all">الكل (يشمل الخارجي)</option>
+          </select>
+          <div class="bulk-target-row">
+            <select id="bulkTargetSheet" style="flex:1"></select>
+          </div>
+          <div class="bulk-inline bulk-new-inline">
+            <input id="bulkNewSheet" type="text" placeholder="اسم ورقة جديدة (داخل الإدارة)">
+            <button id="bulkCreateSheet" class="btn-ghost">إنشاء ورقة</button>
+          </div>
+          <div id="bulkExternalWrap" class="bulk-external" style="display:none;">
+            <div id="bulkExternalFileLabel" class="muted"></div>
+            <div class="bulk-target-row">
+              <select id="bulkExternalTargetSheet" style="flex:1"></select>
+              <button id="bulkExternalRefreshSheets" class="btn-ghost" title="تحديث قائمة الأوراق الخارجية">↻</button>
+            </div>
+            <div class="bulk-inline">
+              <input id="bulkExternalNewSheet" type="text" placeholder="اسم ورقة جديدة (خارجية)">
+              <button id="bulkExternalCreateSheet" class="btn-ghost">إنشاء</button>
+            </div>
+            <div id="bulkExternalNote" class="muted"></div>
+          </div>
+          <div class="bulk-colors">
+            <input id="bulkAdminColor" type="color" value="#fde68a" aria-label="لون الإدارة">
+            <input id="bulkWithdrawColor" type="color" value="#9629ff" aria-label="لون سحب وكالة">
+            <input id="bulkDiscount" type="number" min="0" max="100" value="0" step="1">
+          </div>
+        </div>
+        <div class="bulk-actions-row">
+          <button id="bulkPasteBtn" class="btn-blue">لصق ثم بحث</button>
+          <button id="bulkExecuteBtn" class="btn-red" disabled>تنفيذ الكل</button>
+          <button id="bulkCopyAllBtn" class="btn-ghost" disabled>نسخ الكل</button>
+          <button id="bulkCopySalaryBtn" class="btn-ghost" disabled>نسخ الراتب فقط</button>
+        </div>
+        <div class="bulk-progress-wrap">
+          <div class="bulk-progress">
+            <div id="bulkProgressBar" class="bulk-progress-bar"></div>
+          </div>
+          <div class="bulk-progress-text">
+            <span id="bulkProgressLabel">0%</span>
+            <span id="bulkSummaryText"></span>
+          </div>
+        </div>
+        <div class="bulk-counters">
+          <div class="bulk-counter" title="عدد الإدخالات"><b id="bulkCountTotal">0</b></div>
+          <div class="bulk-counter" title="ملوّن"><b id="bulkCountColored">0</b></div>
+          <div class="bulk-counter" title="غير ملوّن"><b id="bulkCountUncolored">0</b></div>
+          <div class="bulk-counter" title="مجموع الرواتب"><b id="bulkSalarySum">0</b></div>
+        </div>
+        <textarea id="bulkIds" placeholder="ألصق عدة IDs (سطر لكل ID أو مفصولة بمسافات)"></textarea>
+        <div class="bulk-table-wrap">
+          <table class="bulk-table">
+            <thead>
+              <tr>
+                <th>#</th>
+                <th>ID</th>
+                <th>الراتب</th>
+                <th>الحالة</th>
+                <th>ملوّن؟</th>
+              </tr>
+            </thead>
+            <tbody id="bulkResultsBody"></tbody>
+          </table>
+          <div id="bulkPagination" class="bulk-pagination">
+            <button id="bulkPrevBtn" class="bulk-page-btn">‹ السابق</button>
+            <span id="bulkPageInfo" class="bulk-page-info"></span>
+            <button id="bulkNextBtn" class="bulk-page-btn">التالي ›</button>
+          </div>
+          <div id="bulkEmptyState" class="bulk-empty">لا توجد نتائج بعد.</div>
+        </div>
+      </section>
+    </div>
+  </div>
+
+  <div id="drawerBackdrop" class="drawer-backdrop"></div>
   <script>
     // عناصر عامة
     const loadCard       = document.getElementById('loadCard');
@@ -586,6 +412,8 @@
     const pasteHint      = document.getElementById('pasteHint');
     const headerSectionLabelEl = document.getElementById('headerSectionLabel');
     const sectionChipEl        = document.getElementById('sectionChip');
+    const menuSectionChipEl   = document.getElementById('menuSectionChip');
+    const menuSectionLabelEl  = document.getElementById('menuSectionLabel');
 
     const resultsBox  = document.getElementById('resultsBox');
     const statusBadge = document.getElementById('statusBadge');
@@ -617,7 +445,6 @@
     const bulkExecuteBtn     = document.getElementById('bulkExecuteBtn');
     const bulkCopyAllBtn     = document.getElementById('bulkCopyAllBtn');
     const bulkCopySalaryBtn  = document.getElementById('bulkCopySalaryBtn');
-    const bulkResetBtn       = document.getElementById('bulkResetBtn');
     const bulkProgressBar    = document.getElementById('bulkProgressBar');
     const bulkProgressLabel  = document.getElementById('bulkProgressLabel');
     const bulkSummaryText    = document.getElementById('bulkSummaryText');
@@ -667,6 +494,7 @@
     const menuReloadBtn   = document.getElementById('menuReload');
     const menuHomeBtn     = document.getElementById('menuHome');
     const menuBulkBtn     = document.getElementById('menuBulk');
+    const personCardToggleBtn = document.getElementById('togglePersonCardBtn');
     const menuSectionSelect = document.getElementById('menuSection');
     const menuSectionStatus = document.getElementById('menuSectionStatus');
     if (menuSectionStatus) {
@@ -683,6 +511,8 @@
     // أدوات سريعة
     const qtColored = document.getElementById('qtColored');
     const qtUncolored = document.getElementById('qtUncolored');
+    const menuQtColored = document.getElementById('menuQtColored');
+    const menuQtUncolored = document.getElementById('menuQtUncolored');
     const qtMode = document.getElementById('qtMode');
     const qtHide = document.getElementById('qtHideLoad');
 
@@ -767,6 +597,11 @@
     let lastProfileIds = [];
     let lastBaseId = '';
 
+    const PERSON_CARD_STORAGE_KEY = 'personCardEnabled';
+    let personCardEnabledState = readStoredPersonCardState();
+    let personListenersAttached = false;
+    let copyMsgResetTimer = null;
+
     let bulkIds = [];
     let bulkResults = [];
     let bulkBusy = false;
@@ -832,6 +667,13 @@
       if (sectionChipEl) {
         sectionChipEl.classList.toggle('is-empty', !safe);
         sectionChipEl.title = safe ? `القسم الحالي: ${safe}` : 'لم يتم اختيار قسم';
+      }
+      if (menuSectionLabelEl) {
+        menuSectionLabelEl.textContent = safe || '—';
+      }
+      if (menuSectionChipEl) {
+        menuSectionChipEl.classList.toggle('is-empty', !safe);
+        menuSectionChipEl.title = safe ? `القسم الحالي: ${safe}` : 'لم يتم اختيار قسم';
       }
       if (window.__aiClient && typeof window.__aiClient.setActiveSection === 'function') {
         window.__aiClient.setActiveSection(safe);
@@ -1027,7 +869,6 @@
       if (bulkExecuteBtn) bulkExecuteBtn.disabled = !hasIds || !bulkAnalyzed || bulkBusy;
       if (bulkCopyAllBtn) bulkCopyAllBtn.disabled = !hasCopyableResults;
       if (bulkCopySalaryBtn) bulkCopySalaryBtn.disabled = !hasCopyableResults;
-      if (bulkResetBtn) bulkResetBtn.disabled = bulkBusy || !bulkExecuted;
     }
 
     function renderBulkResults(){
@@ -1481,23 +1322,6 @@
       }
     }
 
-    function resetBulkTool(){
-      if (bulkBusy) return;
-      cancelBulkAutoAnalyze();
-      if (bulkIdsInput) bulkIdsInput.value = '';
-      bulkIds = [];
-      bulkResults = [];
-      bulkAnalyzed = false;
-      bulkExecuted = false;
-      bulkPage = 1;
-      renderBulkResults();
-      updateBulkCounters();
-      updateBulkButtons();
-      updateBulkProgress(0, 1, '');
-      if (bulkEmptyState) bulkEmptyState.style.display = '';
-      if (bulkStatusText) bulkStatusText.textContent = 'تمت إعادة التعيين.';
-    }
-
     async function handleBulkPaste(){
       try {
         const txt = await navigator.clipboard.readText();
@@ -1515,34 +1339,172 @@
     }
 
     /******** قسم البيانات (إخفاء/تعطيل) ********/
-    function isPersonFeatureDisabled(){ return localStorage.getItem('disable_person_feature') === '1'; }
-    function isPersonHidden(){ return localStorage.getItem('hide_person_section') === '1'; }
+    function readStoredPersonCardState(){
+      try {
+        const stored = localStorage.getItem(PERSON_CARD_STORAGE_KEY);
+        if (stored === null) {
+          const legacy = localStorage.getItem('disable_person_feature');
+          if (legacy === '1') return false;
+          return true;
+        }
+        return stored !== 'false';
+      } catch (_) {
+        return true;
+      }
+    }
+
+    function isPersonFeatureDisabled(){
+      return !personCardEnabledState;
+    }
+
+    function isPersonHidden(){
+      return localStorage.getItem('hide_person_section') === '1';
+    }
+
+    function resetCopyMsgLabel(){
+      if (copyMsgBtn) {
+        copyMsgBtn.textContent = 'نسخ الرسالة';
+      }
+      if (copyMsgResetTimer){
+        clearTimeout(copyMsgResetTimer);
+        copyMsgResetTimer = null;
+      }
+    }
+
+    function cancelPersonCardOperations(){
+      lastProfileIds = [];
+      personMsg.value = '';
+      personNote.textContent = '—';
+      resetCopyMsgLabel();
+    }
+
+    function updatePersonToggleUI(){
+      if (personCardToggleBtn){
+        personCardToggleBtn.textContent = personCardEnabledState ? 'إيقاف بيانات صاحب الـID' : 'تفعيل بيانات صاحب الـID';
+      }
+      if (qtDisablePerson){
+        qtDisablePerson.checked = !personCardEnabledState;
+      }
+    }
+
+    function attachPersonCardListeners(){
+      if (personListenersAttached) return;
+      if (copyMsgBtn) copyMsgBtn.addEventListener('click', handleCopyMsgClick);
+      if (colorAllBtn) colorAllBtn.addEventListener('click', handleColorAllClick);
+      personListenersAttached = true;
+    }
+
+    function detachPersonCardListeners(){
+      if (!personListenersAttached) return;
+      if (copyMsgBtn) copyMsgBtn.removeEventListener('click', handleCopyMsgClick);
+      if (colorAllBtn) colorAllBtn.removeEventListener('click', handleColorAllClick);
+      personListenersAttached = false;
+    }
 
     function applyPersonVisibility(){
-      qtDisablePerson.checked = isPersonFeatureDisabled();
+      updatePersonToggleUI();
       const hidden = isPersonHidden() || isPersonFeatureDisabled();
-      personCardEl.style.display = hidden ? 'none' : '';
+      if (personCardEl) personCardEl.style.display = hidden ? 'none' : '';
       if (isPersonFeatureDisabled()){
-        personMsg.value = '';
-        personNote.textContent = '—';
-        copyMsgBtn.disabled = true;
-        colorAllBtn.disabled = true;
+        detachPersonCardListeners();
+        cancelPersonCardOperations();
+        if (copyMsgBtn) copyMsgBtn.disabled = true;
+        if (colorAllBtn) colorAllBtn.disabled = true;
       } else {
-        copyMsgBtn.disabled = false;
-        colorAllBtn.disabled = false;
+        attachPersonCardListeners();
+        if (copyMsgBtn) copyMsgBtn.disabled = false;
+        if (colorAllBtn) colorAllBtn.disabled = false;
       }
-      qtHidePerson.textContent = hidden ? '👀 إظهار قسم البيانات' : '🙈 إخفاء قسم البيانات';
+      if (qtHidePerson){
+        qtHidePerson.textContent = hidden ? '👀 إظهار قسم البيانات' : '🙈 إخفاء قسم البيانات';
+      }
     }
-    qtHidePerson.addEventListener('click', ()=>{
-      const cur = isPersonHidden();
-      localStorage.setItem('hide_person_section', cur ? '0':'1');
+
+    function setPersonCardEnabled(enabled){
+      const next = !!enabled;
+      if (next === personCardEnabledState) return;
+      personCardEnabledState = next;
+      try { localStorage.setItem(PERSON_CARD_STORAGE_KEY, next ? 'true' : 'false'); } catch (_) {}
+      updatePersonToggleUI();
       applyPersonVisibility();
-    });
-    qtDisablePerson.addEventListener('change', ()=>{
-      const en = !!qtDisablePerson.checked;
-      localStorage.setItem('disable_person_feature', en ? '1':'0');
-      applyPersonVisibility();
-    });
+      if (personCardEnabledState && lastBaseId){
+        renderPersonCard(lastBaseId);
+      }
+    }
+
+    async function handleCopyMsgClick(){
+      if (isPersonFeatureDisabled()) return;
+      const text = personMsg.value || '';
+      try {
+        await navigator.clipboard.writeText(text);
+        if (copyMsgBtn) {
+          copyMsgBtn.textContent = '✓ نُسخت';
+          copyMsgResetTimer = setTimeout(resetCopyMsgLabel, 900);
+        }
+      } catch (_) {
+        if (!personMsg) return;
+        personMsg.select();
+        document.execCommand('copy');
+        if (copyMsgBtn) {
+          copyMsgBtn.textContent = '✓ نُسخت';
+          copyMsgResetTimer = setTimeout(resetCopyMsgLabel, 900);
+        }
+      }
+    }
+
+    function handleColorAllClick(){
+      if (isPersonFeatureDisabled()) { if (personNote) personNote.textContent='الميزة معطّلة.'; return; }
+      if (!lastProfileIds.length){ if (personNote) personNote.textContent='لا IDs لتلوينها.'; return; }
+      const sheet = sheetSelect.value;
+      const targetMode = targetModeSel.value;
+      if (targetMode==='both' && !sheet){ advNote.textContent='اختر ورقة الهدف أولاً.'; return; }
+
+      if (personNote) personNote.textContent = 'جارٍ التلوين...';
+      let done=0, fail=0;
+      const runOne = (uid)=> new Promise((resolve)=>{
+        google.script.run
+          .withSuccessHandler(_=>{ done++; resolve(true); })
+          .withFailureHandler(_=>{ fail++; resolve(false); })
+          .applyAdvancedAction(uid, sheet, adminColor.value, withdrawColor.value, targetMode);
+      });
+      Promise.all(lastProfileIds.map(runOne)).then(()=>{
+        if (isPersonFeatureDisabled()) { cancelPersonCardOperations(); return; }
+        if(personNote) personNote.textContent = `تم — ملوّن: ${done}, فشل: ${fail}`;
+        flash(personCardEl,'flash-green');
+        if(localMap){
+          lastProfileIds.forEach(uid=>{
+            if(!localMap[uid]) return;
+            localMap[uid].aCol = true;
+            if (targetMode==='both') localMap[uid].dCol = true;
+          });
+        }
+        markJustColored(lastProfileIds, targetMode);
+        refreshCountsLive();
+      });
+    }
+
+    if (qtHidePerson){
+      qtHidePerson.addEventListener('click', ()=>{
+        const cur = isPersonHidden();
+        localStorage.setItem('hide_person_section', cur ? '0':'1');
+        applyPersonVisibility();
+      });
+    }
+
+    if (qtDisablePerson){
+      qtDisablePerson.addEventListener('change', ()=>{
+        const enable = !qtDisablePerson.checked;
+        setPersonCardEnabled(enable);
+      });
+    }
+
+    if (personCardToggleBtn){
+      personCardToggleBtn.addEventListener('click', ()=>{
+        setPersonCardEnabled(!personCardEnabledState);
+      });
+    }
+
+    applyPersonVisibility();
 
     /******** أدوات مساعدة UI ********/
     function flash(el, cls){
@@ -1673,7 +1635,6 @@
     if (bulkExecuteBtn) bulkExecuteBtn.addEventListener('click', runBulkExecute);
     if (bulkCopyAllBtn) bulkCopyAllBtn.addEventListener('click', () => copyBulk('all'));
     if (bulkCopySalaryBtn) bulkCopySalaryBtn.addEventListener('click', () => copyBulk('salary'));
-    if (bulkResetBtn) bulkResetBtn.addEventListener('click', resetBulkTool);
     if (bulkPrevBtn) bulkPrevBtn.addEventListener('click', () => {
       if (bulkPage > 1) {
         bulkPage--;
@@ -1916,6 +1877,7 @@
       lastProfileIds = [];
       google.script.run
         .withSuccessHandler(card=>{
+          if (isPersonFeatureDisabled()) { cancelPersonCardOperations(); return; }
           if(!card || !card.ok){
             personNote.textContent = card?.message || 'لم يتم العثور على بيانات.';
             personMsg.value = '';
@@ -1943,6 +1905,7 @@
           }
         })
         .withFailureHandler(err=>{
+          if (isPersonFeatureDisabled()) { cancelPersonCardOperations(); return; }
           personNote.textContent = 'خطأ: ' + (err?.message||'');
           personMsg.value = '';
         })
@@ -1954,6 +1917,7 @@
       if (lastBaseId){
         google.script.run
           .withSuccessHandler(card=>{
+            if (isPersonFeatureDisabled()) { cancelPersonCardOperations(); return; }
             if(card && card.ok){
               personMsg.value = buildMessageText(card, !!applyDiscountToMessage.checked, localMap);
               personNote.textContent = `تم — عدد IDs: ${(card.ids||[]).length}`;
@@ -1962,46 +1926,6 @@
           .getPersonCardById(lastBaseId);
       }
     }
-
-    copyMsgBtn.addEventListener('click', async ()=>{
-      try{
-        await navigator.clipboard.writeText(personMsg.value||'');
-        copyMsgBtn.textContent = '✓ نُسخت';
-        setTimeout(()=> copyMsgBtn.textContent='نسخ الرسالة', 900);
-      }catch(_){
-        personMsg.select(); document.execCommand('copy');
-      }
-    });
-
-    colorAllBtn.addEventListener('click', ()=>{
-      if (isPersonFeatureDisabled()) { personNote.textContent='الميزة معطّلة.'; return; }
-      if (!lastProfileIds.length){ personNote.textContent='لا IDs لتلوينها.'; return; }
-      const sheet = sheetSelect.value;
-      const targetMode = targetModeSel.value;
-      if (targetMode==='both' && !sheet){ advNote.textContent='اختر ورقة الهدف أولاً.'; return; }
-
-      personNote.textContent = 'جارٍ التلوين...';
-      let done=0, fail=0;
-      const runOne = (uid)=> new Promise((resolve)=>{
-        google.script.run
-          .withSuccessHandler(_=>{ done++; resolve(true); })
-          .withFailureHandler(_=>{ fail++; resolve(false); })
-          .applyAdvancedAction(uid, sheet, adminColor.value, withdrawColor.value, targetMode);
-      });
-      Promise.all(lastProfileIds.map(runOne)).then(()=>{
-        personNote.textContent = `تم — ملوّن: ${done}, فشل: ${fail}`;
-        flash(personCardEl,'flash-green');
-        if(localMap){
-          lastProfileIds.forEach(uid=>{
-            if(!localMap[uid]) return;
-            localMap[uid].aCol = true;
-            if (targetMode==='both') localMap[uid].dCol = true;
-          });
-        }
-        markJustColored(lastProfileIds, targetMode);
-        refreshCountsLive();
-      });
-    });
 
     /******** تنفيذ ذكي ********/
     function runAdvanced() {
@@ -2046,14 +1970,22 @@
           if(!res || !res.ok){
             if (qtColored) qtColored.textContent = '—';
             if (qtUncolored) qtUncolored.textContent = '—';
+            if (menuQtColored) menuQtColored.textContent = '—';
+            if (menuQtUncolored) menuQtUncolored.textContent = '—';
             return;
           }
-          if (qtColored) qtColored.textContent   = fmtNum(res.coloredRows || 0);
-          if (qtUncolored) qtUncolored.textContent = fmtNum(res.uncoloredRows || 0);
+          const coloredVal = fmtNum(res.coloredRows || 0);
+          const uncoloredVal = fmtNum(res.uncoloredRows || 0);
+          if (qtColored) qtColored.textContent = coloredVal;
+          if (qtUncolored) qtUncolored.textContent = uncoloredVal;
+          if (menuQtColored) menuQtColored.textContent = coloredVal;
+          if (menuQtUncolored) menuQtUncolored.textContent = uncoloredVal;
         })
         .withFailureHandler(()=>{
           if (qtColored) qtColored.textContent = '—';
           if (qtUncolored) qtUncolored.textContent = '—';
+          if (menuQtColored) menuQtColored.textContent = '—';
+          if (menuQtUncolored) menuQtUncolored.textContent = '—';
         })
         .getLiveStatsForFooter(pct);
     }
@@ -2188,7 +2120,11 @@
           return;
         }
         renderResult(res);
-        renderPersonCard(id);
+        if (isPersonFeatureDisabled()) {
+          cancelPersonCardOperations();
+        } else {
+          renderPersonCard(id);
+        }
       })
       .withFailureHandler(err=>{
         if (err && err.message) renderResult({ status:'error', message: err.message });
@@ -2224,7 +2160,7 @@
         debounceTimer = setTimeout(()=>{
           if (lastResult) renderResult(lastResult);
           refreshCountsLive(pct);
-          if (applyDiscountToMessage?.checked && lastBaseId) rebuildPersonCardUsingLast();
+          if (!isPersonFeatureDisabled() && applyDiscountToMessage?.checked && lastBaseId) rebuildPersonCardUsingLast();
         }, 120);
       });
     })();
@@ -2262,7 +2198,7 @@
           .withSuccessHandler(res=>{
             if (!res || typeof res.enabled === 'undefined') return;
             if (!!res.enabled !== desired) enableSalaryCorrection.checked = !!res.enabled;
-            if (lastBaseId) rebuildPersonCardUsingLast();
+            if (!isPersonFeatureDisabled() && lastBaseId) rebuildPersonCardUsingLast();
           })
           .withFailureHandler(()=>{ enableSalaryCorrection.checked = !desired; })
           .setSalaryCorrectionEnabled(desired ? 1 : 0);
@@ -2416,7 +2352,7 @@
   .lgp-sheet{width:min(92vw,560px);padding:14px;background:var(--card-bg,#111827);color:var(--fg,#e5e7eb);
     box-shadow:0 12px 28px rgba(0,0,0,.25);border:1px solid var(--border,#374151);border-radius:12px;overflow:hidden}
   .lgp-title{display:flex;align-items:center;justify-content:space-between;margin-bottom:8px}
-  .lgp-title h3{margin:0;font-size:16px;font-weight:800}
+  .lgp-heading{font-size:16px;font-weight:800}
   .lgp-ghost{border:1px solid var(--border,#374151);background:transparent;padding:8px 12px;color:inherit;border-radius:12px}
 
   .lgp-list{max-height:56vh;overflow:auto;border:1px solid var(--border,#374151);background:rgba(255,255,255,.02);border-radius:12px}
@@ -2450,7 +2386,7 @@
 <div id="lgpModal" class="lgp-modal" role="dialog" aria-modal="true">
   <div class="lgp-sheet">
     <div class="lgp-title">
-      <h3>📁 سجل النقل (آخر 15)</h3>
+      <div class="lgp-heading" aria-hidden="true">📁</div>
       <button id="lgpClose" class="lgp-ghost">إغلاق</button>
     </div>
 
@@ -2463,10 +2399,9 @@
         <option>… جارٍ التحميل</option>
       </select>
 
-      <div class="lgp-toggle">
-        <span style="font-size:12px;opacity:.8">لون مخصّص</span>
+      <div class="lgp-toggle" title="لون مخصّص">
         <label class="ios-switch">
-          <input id="lgpUseCustom" type="checkbox">
+          <input id="lgpUseCustom" type="checkbox" aria-label="لون مخصّص">
           <span class="track"></span><span class="thumb"></span>
         </label>
       </div>


### PR DESCRIPTION
## Summary
- add a sidebar toggle that enables or disables the personCard section with stored state and listener management
- guard person-card server calls and message helpers based on the new toggle while keeping legacy hide controls working
- keep the bulk new-sheet row horizontal on mobile, remove the reset button, and maintain light shadows per spec

## Testing
- Not run (UI-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68e561bd19bc832484db9eba0fe0c146